### PR TITLE
fix(validation-group): clean up of path observer subscriptions on validation group destroy

### DIFF
--- a/src/validation/path-observer.js
+++ b/src/validation/path-observer.js
@@ -114,8 +114,18 @@ export class PathObserver {
   subscribe(callback) {
     this.callbacks.unshift(callback);
     if (this.observers.length === this.path.length) {
-      return this.observers[this.observers.length - 1].subscribe(callback);
+      this.subscription = this.observers[this.observers.length - 1].subscribe(callback);
+      return () => this.unsubscribe();
     }
-    //TODO proper cleanup of callbacks
+  }
+
+  unsubscribe() {
+    if(this.subscription) this.subscription();
+    for (let i = this.observers.length - 1; i >= 0; i--) {
+      var observer = this.observers.pop();
+      if (observer && observer.subscription) {
+        observer.subscription();
+      }
+    }
   }
 }

--- a/src/validation/validation-group.js
+++ b/src/validation/validation-group.js
@@ -38,7 +38,11 @@ export class ValidationGroup {
   }
 
   destroy(){
-    this.onDestroy(); //todo: what else needs to be done for proper cleanup?
+    for (var i = this.validationProperties.length - 1; i >= 0; i--) {
+      this.validationProperties[i].destroy();
+    }
+    this.onDestroy();
+    // TODO: what else needs to be done for proper cleanup?
   }
 
   clear(){

--- a/src/validation/validation-property.js
+++ b/src/validation/validation-property.js
@@ -16,7 +16,7 @@ export class ValidationProperty {
 
     this.debouncer = new Debouncer(config.getDebounceTimeout());
 
-    this.observer.subscribe(() => {
+    this.subscription = this.observer.subscribe(() => {
       this.debouncer.debounce( () => {
         var newValue =   this.observer.getValue();
         if(newValue !== this.latestValue) {
@@ -53,6 +53,11 @@ export class ValidationProperty {
   clear(){
     this.latestValue = this.observer.getValue();
     this.propertyResult.clear();
+  }
+
+  destroy() {
+    if(this.subscription) this.subscription();
+    // TODO: what else needs to be done for proper cleanup?
   }
 
   /**


### PR DESCRIPTION
I've improved the `destroy()` function on `ValidationGroup`.

Now calling `destroy()` will clean up the subscription of the `PathObserver` for each `ValidationResultProperty` (now `PathObserver` has an `unsubscribe()` method).

I was having issues with a form with a dynamic array of values, recreating the validation group was creating new observers each time and some fields ended up triggering multiple validations (also on other fields of the form when adding and removing element of an array).

Calling `destroy()` on the `ValidationGroup` and recreating it solves the issue with this patch, since all observables get unsubscribed correctly.