### PR TITLE
fix(viewstrategy) p-element containing validationmessage now toggles display:block/none

### DIFF
--- a/src/validation/validate-custom-attribute-view-strategy.js
+++ b/src/validation/validate-custom-attribute-view-strategy.js
@@ -97,10 +97,14 @@ export class TWBootstrapViewStrategy extends ValidateCustomAttributeViewStrategy
         element.parentNode.appendChild(helpBlock);
       }
     }
-    if (validationProperty)
+    if (validationProperty) {
       helpBlock.textContent = validationProperty.message;
-    else
+      helpBlock.style.display = validationProperty.message ? 'block' : 'none';
+    }
+    else {
       helpBlock.textContent = '';
+      helpBlock.style.display = 'none';
+    }
   }
 
 

--- a/test/validateCustomAttribute/validate-custom-attribute.spec.js
+++ b/test/validateCustomAttribute/validate-custom-attribute.spec.js
@@ -153,6 +153,7 @@ describe('Tests on ValidateCustomAttribute', () => {
       expect(firstNameMessage.classList.contains('aurelia-validation-message')).toBe(true);
       expect(firstNameMessage.classList.contains('help-block')).toBe(true);
       expect(firstNameMessage.textContent).toBe('is required');
+      expect(firstNameMessage.style.display).toBe('block');
 
 
       //default: adds <p> after element
@@ -161,6 +162,7 @@ describe('Tests on ValidateCustomAttribute', () => {
       expect(lastNameMessage.classList.contains('aurelia-validation-message')).toBe(true);
       expect(lastNameMessage.classList.contains('help-block')).toBe(true);
       expect(lastNameMessage.textContent).toBe('');
+      expect(lastNameMessage.style.display).toBe('none');
       return Promise.resolve(true);
     }, true);
 
@@ -207,6 +209,7 @@ describe('Tests on ValidateCustomAttribute', () => {
       expect(firstNameMessage.classList.contains('aurelia-validation-message')).toBe(true);
       expect(firstNameMessage.classList.contains('help-block')).toBe(true);
       expect(firstNameMessage.textContent).toBe('is required');
+      expect(firstNameMessage.style.display).toBe('block');
 
 
       //default: adds <p> after element
@@ -215,6 +218,7 @@ describe('Tests on ValidateCustomAttribute', () => {
       expect(lastNameMessage.classList.contains('aurelia-validation-message')).toBe(true);
       expect(lastNameMessage.classList.contains('help-block')).toBe(true);
       expect(lastNameMessage.textContent).toBe('');
+      expect(lastNameMessage.style.display).toBe('none');
       return Promise.resolve(true);
     }, true);
 
@@ -254,6 +258,7 @@ describe('Tests on ValidateCustomAttribute', () => {
       expect(addressMessage.classList.contains('aurelia-validation-message')).toBe(true);
       expect(addressMessage.classList.contains('help-block')).toBe(true);
       expect(addressMessage.textContent).toBe('');
+      expect(addressMessage.style.display).toBe('none');
       return Promise.resolve(true);
     }, true);
 
@@ -294,6 +299,7 @@ describe('Tests on ValidateCustomAttribute', () => {
       expect(firstNameMessage.classList.contains('aurelia-validation-message')).toBe(true);
       expect(firstNameMessage.classList.contains('help-block')).toBe(true);
       expect(firstNameMessage.textContent).toBe('');
+      expect(firstNameMessage.style.display).toBe('none');
 
 
       //default: adds <p> after element
@@ -302,6 +308,7 @@ describe('Tests on ValidateCustomAttribute', () => {
       expect(lastNameMessage.classList.contains('aurelia-validation-message')).toBe(true);
       expect(lastNameMessage.classList.contains('help-block')).toBe(true);
       expect(lastNameMessage.textContent).toBe('');
+      expect(lastNameMessage.style.display).toBe('none');
       done();
     }, 0);
   });
@@ -346,6 +353,7 @@ describe('Tests on ValidateCustomAttribute', () => {
         expect(firstNameMessage.classList.contains('aurelia-validation-message')).toBe(true);
         expect(firstNameMessage.classList.contains('help-block')).toBe(true);
         expect(firstNameMessage.textContent).toBe('is required');
+        expect(firstNameMessage.style.display).toBe('block');
 
 
         //default: adds <p> after element
@@ -354,6 +362,7 @@ describe('Tests on ValidateCustomAttribute', () => {
         expect(lastNameMessage.classList.contains('aurelia-validation-message')).toBe(true);
         expect(lastNameMessage.classList.contains('help-block')).toBe(true);
         expect(lastNameMessage.textContent).toBe('');
+        expect(lastNameMessage.style.display).toBe('none');
         return Promise.resolve(true);
       }, true);
 
@@ -401,6 +410,7 @@ describe('Tests on ValidateCustomAttribute', () => {
       expect(streetMessage.classList.contains('aurelia-validation-message')).toBe(true);
       expect(streetMessage.classList.contains('help-block')).toBe(true);
       expect(streetMessage.textContent).toBe('is required');
+      expect(streetMessage.style.display).toBe('block');
 
 
       //default: adds <p> after element
@@ -409,6 +419,7 @@ describe('Tests on ValidateCustomAttribute', () => {
       expect(numberMessage.classList.contains('aurelia-validation-message')).toBe(true);
       expect(numberMessage.classList.contains('help-block')).toBe(true);
       expect(numberMessage.textContent).toBe('');
+      expect(numberMessage.style.display).toBe('none');
       return Promise.resolve(true);
     }, true);
 
@@ -453,6 +464,7 @@ describe('Tests on ValidateCustomAttribute', () => {
       expect(firstNameMessage.classList.contains('aurelia-validation-message')).toBe(true);
       expect(firstNameMessage.classList.contains('help-block')).toBe(true);
       expect(firstNameMessage.textContent).toBe('is required');
+      expect(firstNameMessage.style.display).toBe('block');
 
 
       //default: adds <p> after element
@@ -461,6 +473,7 @@ describe('Tests on ValidateCustomAttribute', () => {
       expect(lastNameMessage.classList.contains('aurelia-validation-message')).toBe(true);
       expect(lastNameMessage.classList.contains('help-block')).toBe(true);
       expect(lastNameMessage.textContent).toBe('');
+      expect(lastNameMessage.style.display).toBe('none');
 
       return Promise.resolve(true);
     }, true);
@@ -468,4 +481,3 @@ describe('Tests on ValidateCustomAttribute', () => {
     expectations.validate();
   });
 });
-


### PR DESCRIPTION
Issue described here:
https://github.com/aurelia/validation/issues/78

Made a quick simple fix to solve it, merge it if you think it's good enough, else throw it. :-)