### PR TITLE
Uses `aurelia-metadata` for metadata handling

### DIFF
--- a/src/validation/decorators.js
+++ b/src/validation/decorators.js
@@ -1,7 +1,9 @@
 import {Metadata} from 'aurelia-metadata';
 
-class ValidationMetadata
+export class ValidationMetadata
 {
+  static metadataKey = 'aurelia:validation';
+  
   constructor(){
     this.properties = [];
   }
@@ -41,7 +43,7 @@ class ValidationPropertyMetadata{
 
 export function ensure(setupStep){
   return function(target, propertyName){
-    var validationMetadata = Metadata.getOrCreateOwn('aurelia:validation', ValidationMetadata, target);
+    var validationMetadata = Metadata.getOrCreateOwn(ValidationMetadata.metadataKey, ValidationMetadata, target);
     var property = validationMetadata.getOrCreateProperty(propertyName);
     property.addSetupStep(setupStep);
   }

--- a/src/validation/decorators.js
+++ b/src/validation/decorators.js
@@ -1,3 +1,5 @@
+import {Metadata} from 'aurelia-metadata';
+
 class ValidationMetadata
 {
   constructor(){
@@ -39,10 +41,8 @@ class ValidationPropertyMetadata{
 
 export function ensure(setupStep){
   return function(target, propertyName){
-    if(target._validationMetadata === undefined){
-      target._validationMetadata = new ValidationMetadata();
-    }
-    var property = target._validationMetadata.getOrCreateProperty(propertyName);
+    var validationMetadata = Metadata.getOrCreateOwn('aurelia:validation', ValidationMetadata, target);
+    var property = validationMetadata.getOrCreateProperty(propertyName);
     property.addSetupStep(setupStep);
   }
 }

--- a/src/validation/validation-group.js
+++ b/src/validation/validation-group.js
@@ -29,7 +29,7 @@ export class ValidationGroup {
       this.validate(false, true) ;});
 
 
-    var validationMetadata = Metadata.getOwn(ValidationMetadata.metadataKey, this.subject.constructor);
+    var validationMetadata = Metadata.getOwn(ValidationMetadata.metadataKey, this.subject);
     if (validationMetadata) {
       validationMetadata.setup(this);
     }

--- a/src/validation/validation-group.js
+++ b/src/validation/validation-group.js
@@ -1,7 +1,8 @@
+import {Metadata} from 'aurelia-metadata';
 import {ValidationGroupBuilder} from '../validation/validation-group-builder';
 import {ValidationResult} from '../validation/validation-result';
 import {ValidationLocale} from '../validation/validation-locale';
-
+import {ValidationMetadata} from '../validation/decorators';
 
 /**
  * Encapsulates validation rules and their current validation state for a given subject
@@ -28,13 +29,10 @@ export class ValidationGroup {
       this.validate(false, true) ;});
 
 
-
-
-    if(this.subject.__proto__._validationMetadata)
-    {
-      this.subject.__proto__._validationMetadata.setup(this);
+    var validationMetadata = Metadata.getOwn(ValidationMetadata.metadataKey, this.subject.constructor);
+    if (validationMetadata) {
+      validationMetadata.setup(this);
     }
-
   }
 
   destroy(){


### PR DESCRIPTION
Cleaner / more compliant with the way it is done in Aurelia.
Fixes #64.

**NOTE**: This creates a direct dependency on `aurelia-metadata`, whose build configuration is _not_ included in this PR.