### PR TITLE
chore(update): Update to latest releases

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,48 +1,50 @@
 System.config({
   "transpiler": "traceur",
   "paths": {
-    "*": "*.js",
     "github:*": "jspm_packages/github/*.js",
-    "npm:*": "jspm_packages/npm/*.js"
-  }
+    "npm:*": "jspm_packages/npm/*.js",
+    "*": "*.js"
+  },
+  "defaultJSExtensions": true
 });
 
 System.config({
   "map": {
-    "aurelia-binding": "github:aurelia/binding@0.8.0",
-    "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.9.0",
-    "aurelia-templating": "github:aurelia/templating@0.13.0",
+    "aurelia-binding": "github:aurelia/binding@0.8.6",
+    "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.9.2",
+    "aurelia-templating": "github:aurelia/templating@0.14.4",
     "traceur": "github:jmcriffey/bower-traceur@0.0.88",
     "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.88",
-    "github:aurelia/binding@0.8.0": {
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.9.0",
-      "aurelia-metadata": "github:aurelia/metadata@0.7.0",
-      "aurelia-task-queue": "github:aurelia/task-queue@0.6.0",
+    "github:aurelia/binding@0.8.6": {
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.9.2",
+      "aurelia-metadata": "github:aurelia/metadata@0.7.3",
+      "aurelia-task-queue": "github:aurelia/task-queue@0.6.2",
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:aurelia/dependency-injection@0.9.0": {
-      "aurelia-logging": "github:aurelia/logging@0.6.0",
-      "aurelia-metadata": "github:aurelia/metadata@0.7.0",
+    "github:aurelia/dependency-injection@0.9.2": {
+      "aurelia-logging": "github:aurelia/logging@0.6.4",
+      "aurelia-metadata": "github:aurelia/metadata@0.7.3",
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:aurelia/loader@0.8.0": {
+    "github:aurelia/loader@0.8.7": {
       "aurelia-html-template-element": "github:aurelia/html-template-element@0.2.0",
-      "aurelia-path": "github:aurelia/path@0.8.0",
+      "aurelia-metadata": "github:aurelia/metadata@0.7.3",
+      "aurelia-path": "github:aurelia/path@0.8.1",
       "core-js": "npm:core-js@0.9.18",
       "webcomponentsjs": "github:webcomponents/webcomponentsjs@0.6.3"
     },
-    "github:aurelia/metadata@0.7.0": {
+    "github:aurelia/metadata@0.7.3": {
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:aurelia/templating@0.13.0": {
-      "aurelia-binding": "github:aurelia/binding@0.8.0",
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.9.0",
+    "github:aurelia/templating@0.14.4": {
+      "aurelia-binding": "github:aurelia/binding@0.8.6",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.9.2",
       "aurelia-html-template-element": "github:aurelia/html-template-element@0.2.0",
-      "aurelia-loader": "github:aurelia/loader@0.8.0",
-      "aurelia-logging": "github:aurelia/logging@0.6.0",
-      "aurelia-metadata": "github:aurelia/metadata@0.7.0",
-      "aurelia-path": "github:aurelia/path@0.8.0",
-      "aurelia-task-queue": "github:aurelia/task-queue@0.6.0",
+      "aurelia-loader": "github:aurelia/loader@0.8.7",
+      "aurelia-logging": "github:aurelia/logging@0.6.4",
+      "aurelia-metadata": "github:aurelia/metadata@0.7.3",
+      "aurelia-path": "github:aurelia/path@0.8.1",
+      "aurelia-task-queue": "github:aurelia/task-queue@0.6.2",
       "core-js": "npm:core-js@0.9.18"
     },
     "github:jspm/nodelibs-process@0.1.1": {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
       "lib": "dist/amd"
     },
     "dependencies": {
-      "aurelia-binding": "github:aurelia/binding@^0.8.0",
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.9.0",
-      "aurelia-templating": "github:aurelia/templating@^0.13.0"
+      "aurelia-binding": "github:aurelia/binding@^0.8.6",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.9.2",
+      "aurelia-templating": "github:aurelia/templating@^0.14.4"
     },
     "devDependencies": {
       "babel": "npm:babel-core@^5.1.13",
@@ -52,7 +52,7 @@
     "karma-babel-preprocessor": "^5.0.1",
     "karma-chrome-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.5",
-    "karma-jspm": "^1.1.5",
+    "karma-jspm": "^2.0.1-beta.2",
     "object.assign": "^1.0.3",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -13,13 +13,13 @@ export {ensure} from './validation/decorators';
 import {ValidationConfig} from './validation/validation-config';
 import {Validation} from './validation/validation';
 
-export function configure(aurelia, configCallback) {
+export function configure(frameworkConfig, configCallback) {
 
-  aurelia.globalizeResources('./validation/validate-custom-attribute');
+  frameworkConfig.globalResources('./validation/validate-custom-attribute');
   if(configCallback !== undefined && typeof(configCallback) === 'function')
   {
     configCallback(Validation.defaults);
   }
-  aurelia.withSingleton(ValidationConfig, Validation.defaults);
+  frameworkConfig.singleton(ValidationConfig, Validation.defaults);
   return Validation.defaults.locale();
 }

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,4 +4,4 @@ import {ValidationConfigDefaults} from '../src/validation/validation-config'
 
 ValidationLocale.Repository.default =
   ValidationLocale.Repository.addLocale('en-US', data);
-ValidationConfigDefaults._defaults.localeResources =  './src/resources/';
+ValidationConfigDefaults._defaults.localeResources =  'src/resources/';


### PR DESCRIPTION
I have updated aurelia-validation to use the latest versions of aurelia. The plugin api has changed, and these changes make the validation plugin work with the latest release. I had to update karma-jspm so that the tests would run with jspm@beta.