### PR TITLE
fix(tests): update dependencies to ensure tests run again

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,24 +1,22 @@
 System.config({
-  "transpiler": "babel",
-  "babelOptions": {
+  defaultJSExtensions: true,
+  transpiler: "babel",
+  babelOptions: {
     "optional": [
       "runtime",
       "optimisation.modules.system"
     ]
   },
-  "paths": {
-    "github:*": "jspm_packages/github/*.js",
-    "npm:*": "jspm_packages/npm/*.js",
-    "*": "*.js"
+  paths: {
+    "github:*": "jspm_packages/github/*",
+    "npm:*": "jspm_packages/npm/*"
   },
-  "defaultJSExtensions": true
-});
 
-System.config({
-  "map": {
+  map: {
     "aurelia-binding": "github:aurelia/binding@0.8.6",
     "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.9.2",
     "aurelia-logging": "github:aurelia/logging@0.6.4",
+    "aurelia-metadata": "github:aurelia/metadata@0.7.3",
     "aurelia-templating": "github:aurelia/templating@0.14.4",
     "babel": "npm:babel-core@5.8.22",
     "babel-runtime": "npm:babel-runtime@5.8.20",
@@ -75,4 +73,3 @@ System.config({
     }
   }
 });
-

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
       "aurelia-binding": "github:aurelia/binding@^0.8.6",
       "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.9.2",
       "aurelia-logging": "github:aurelia/logging@^0.6.4",
+      "aurelia-metadata": "github:aurelia/metadata@^0.7.3",
       "aurelia-templating": "github:aurelia/templating@^0.14.4"
     },
     "devDependencies": {
@@ -39,21 +40,21 @@
     }
   },
   "devDependencies": {
-    "aurelia-tools": "^0.1.3",
+    "aurelia-tools": "^0.1.6",
     "conventional-changelog": "0.0.11",
     "del": "^1.1.0",
     "gulp": "^3.8.10",
     "gulp-babel": "^5.1.0",
-    "gulp-bump": "^0.1.11",
+    "gulp-bump": "^0.3.1",
     "gulp-jshint": "^1.9.0",
     "gulp-yuidoc": "^0.1.2",
     "jasmine-core": "^2.1.3",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.28",
-    "karma-babel-preprocessor": "^5.0.1",
+    "karma-babel-preprocessor": "^5.2.1",
     "karma-chrome-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.5",
-    "karma-jspm": "^1.1.5",
+    "karma-jspm": "^2.0.1",
     "object.assign": "^1.0.3",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,4 +4,4 @@ import {ValidationConfigDefaults} from '../src/validation/validation-config'
 
 ValidationLocale.Repository.default =
   ValidationLocale.Repository.addLocale('en-US', data);
-ValidationConfigDefaults._defaults.localeResources =  './src/resources/';
+ValidationConfigDefaults._defaults.localeResources =  'src/resources/';


### PR DESCRIPTION
There were two missing parts to the latest PR to update
dependencies in aurelia-validation:

 * aurelia-metadata must be brought in as a dependency
 * there was an error with the test reference to resources