### PR TITLE
Fix validating length of numbers

### DIFF
--- a/src/validation-rules.js
+++ b/src/validation-rules.js
@@ -290,6 +290,7 @@ export class MinimumLengthValidationRule extends ValidationRule {
     super(
       minimumLength,
       (newValue, minLength) => {
+        newValue = typeof newValue == 'number' ? newValue.toString() : newValue;
         return newValue.length !== undefined && newValue.length >= minLength;
       },
       null,
@@ -303,6 +304,7 @@ export class MaximumLengthValidationRule extends ValidationRule {
     super(
       maximumLength,
       (newValue, maxLength) => {
+        newValue = typeof newValue == 'number' ? newValue.toString() : newValue;
         return newValue.length !== undefined && newValue.length <= maxLength;
       },
       null,
@@ -316,6 +318,7 @@ export class BetweenLengthValidationRule extends ValidationRule {
     super(
       {minimumLength: minimumLength, maximumLength: maximumLength},
       (newValue, threshold) => {
+        newValue = typeof newValue == 'number' ? newValue.toString() : newValue;
         return newValue.length !== undefined
           && newValue.length >= threshold.minimumLength
           && newValue.length <= threshold.maximumLength;

--- a/test/validationRules/between-length.spec.js
+++ b/test/validationRules/between-length.spec.js
@@ -15,6 +15,18 @@ describe('Tests on BetweenLengthValidationRule', () => {
     expectations.validate();
   });
 
+  it('should be working with simple numbers', (done) => {
+    var expectations = new Expectations(expect, done);
+    var rule = new BetweenLengthValidationRule(2, 3);
+    expectations.expectAsync(rule.validate(1)).toBe(false);
+    expectations.expectAsync(rule.validate(12)).toBe(true);
+    expectations.expectAsync(rule.validate(1.2)).toBe(true);
+    expectations.expectAsync(rule.validate(123)).toBe(true);
+    expectations.expectAsync(rule.validate(1234)).toBe(false);
+    expectations.expectAsync(rule.validate(0.00)).toBe(false);
+    expectations.validate();
+  });
+
   it('should trim strings before evaluating', (done) => {
     var expectations = new Expectations(expect, done);
     var rule = new BetweenLengthValidationRule(2, 3);
@@ -24,6 +36,7 @@ describe('Tests on BetweenLengthValidationRule', () => {
     expectations.expectAsync(rule.validate('  a  ')).toBe(false);
     expectations.validate();
   });
+  
   it('should be working with arrays', (done) => {
     var expectations = new Expectations(expect, done);
     var rule = new BetweenLengthValidationRule(2, 3);

--- a/test/validationRules/maximum-length.spec.js
+++ b/test/validationRules/maximum-length.spec.js
@@ -14,6 +14,16 @@ describe('Tests on MaximumLengthValidationRule', () => {
     expectations.validate();
   });
 
+  it('should be working with simple numbers', (done) => {
+    var expectations = new Expectations(expect, done);
+    var rule = new MaximumLengthValidationRule(2);
+    expectations.expectAsync(rule.validate(1)).toBe(true);
+    expectations.expectAsync(rule.validate(12)).toBe(true);
+    expectations.expectAsync(rule.validate(123)).toBe(false);
+    expectations.expectAsync(rule.validate(1234)).toBe(false);
+    expectations.validate();
+  });
+
   it('should not trim strings before evaluating', (done) => {
     var expectations = new Expectations(expect, done);
     var rule = new MaximumLengthValidationRule(2);

--- a/test/validationRules/minum-length.spec.js
+++ b/test/validationRules/minum-length.spec.js
@@ -14,6 +14,16 @@ describe('Tests on MinimumLengthValidationRule', () => {
     expectations.validate();
   });
 
+  it('should be working with simple numbers', (done) => {
+    var expectations = new Expectations(expect, done);
+    var rule = new MinimumLengthValidationRule(3);
+    expectations.expectAsync(rule.validate(1)).toBe(false);
+    expectations.expectAsync(rule.validate(12)).toBe(false);
+    expectations.expectAsync(rule.validate(123)).toBe(true);
+    expectations.expectAsync(rule.validate(1234)).toBe(true);
+    expectations.validate();
+  });
+
   it('should not trim strings before evaluating', (done) => {
     var expectations = new Expectations(expect, done);
     var rule = new MinimumLengthValidationRule(3);


### PR DESCRIPTION
Validating the length of numbers was broken in a few places, as noted in #136, here are some fixes.

Basically the bug happens because length is measured and compared using `.length`, which is not a method on `Number`, so I'm checking the `typeof` on values passed into `BetweenLengthValidationRule`, `MaximumLengthValidationRule` and `MinimumLengthValidationRule`. If it's a `Number`, convert it to a `String`.

Simples.

This is my first PR, so if I've done something per convention please let me know.

:heart: 