### PR TITLE
Validate also arrays

### DIFF
--- a/src/path-observer.js
+++ b/src/path-observer.js
@@ -36,7 +36,12 @@ export class PathObserver {
       let subscription;
       let currentValue;
       if (!observer) {
-        observer = this.observerLocator.getObserver(currentSubject, currentPath);
+        if (Array.isArray(currentSubject[currentPath])) {
+          observer = this.observerLocator.getArrayObserver(currentSubject[currentPath]);
+        }
+        else {
+          observer = this.observerLocator.getObserver(currentSubject, currentPath);
+        }
         this.observers.push(observer);
         subscription = observer.subscribe((newValue, oldValue) => {
           this.observeParts(observer.propertyName);
@@ -67,7 +72,12 @@ export class PathObserver {
   getObserver() {
     if (this.path.length === 1) {
       this.subject[this.path[0]]; //binding issue with @bindable properties, see: https://github.com/aurelia/binding/issues/89
-      return this.observerLocator.getObserver(this.subject, this.path[0]);
+      if (Array.isArray(this.subject[this.path[0]])) {
+        observer = this.observerLocator.getArrayObserver(this.subject[this.path[0]]);
+      }
+      else {
+        observer = this.observerLocator.getObserver(this.subject, this.path[0]);
+      }
     }
     return this;
   }

--- a/src/validation-property.js
+++ b/src/validation-property.js
@@ -59,11 +59,29 @@ export class ValidationProperty {
    */
   validate(newValue, shouldBeDirty, forceExecution) {
     if ((!this.propertyResult.isDirty && shouldBeDirty) || this.latestValue !== newValue || forceExecution) {
-      this.latestValue = newValue;
+      this.latestValue = Array.isArray(newValue) ? newValue.slice(0) : newValue;
       return this.config.locale().then((locale) => {
         return this.collectionOfValidationRules.validate(newValue, locale)
           .then((validationResponse) => {
-            if (this.latestValue === validationResponse.latestValue) {
+            let equal = (function equal(var1, var2) {
+              if (typeof var1 === 'object' && var2) {
+                if (Object.keys(var1).length == Object.keys(var2).length) {
+                  for (let i in var1) {
+                    if (var1.hasOwnProperty(i)) {
+                      return equal(var1[i], var2[i]);
+                    }
+                  }
+                  return true; // the object/array must be empty
+                }
+                else {
+                  return false;
+                }
+              }
+              else {
+                return var1 == var2;
+              }
+            })(this.latestValue, validationResponse.latestValue);
+            if (equal) {
               this.propertyResult.setValidity(validationResponse, shouldBeDirty);
             }
             return validationResponse.isValid;


### PR DESCRIPTION
Currently the validation isn't able to validate arrays which comes from custom elements because i wasa using only the property observer. I changed that to use either the property or the array observer and to  compare the old and new value deep.

This pr requires changes on binding repo. The getValue function was missing on array and collection observer. 
https://github.com/aurelia/binding/pull/179