### PR TITLE
Fixed redundant check/radio input validation messages

### DIFF
--- a/dist/es6/strategies/twbootstrap-view-strategy.js
+++ b/dist/es6/strategies/twbootstrap-view-strategy.js
@@ -27,7 +27,7 @@ export class TWBootstrapViewStrategyBase extends ValidationViewStrategy {
   }
 
   findLabelsRecursively(currentElement, inputId, currentLabels, currentDepth) {
-    if (currentDepth === 5) {
+    if (currentDepth === 5 || currentLabels.length == 1) {
       return;
     }
     if (currentElement.nodeName === 'LABEL' &&


### PR DESCRIPTION
This is needed to prevent adding the validation error multiple times to radio or checkbox labels. The first label in the form group is the label for the group. Each subsequent label might be wrapping the check/radio inputs and should not receive the message. 
http://getbootstrap.com/css/#inline-checkboxes-and-radios