### PR TITLE
Fixed redundant check/radio input validation messages

### DIFF
--- a/dist/amd/strategies/twbootstrap-view-strategy.js
+++ b/dist/amd/strategies/twbootstrap-view-strategy.js
@@ -38,7 +38,7 @@ define(['exports', '../validation-view-strategy'], function (exports, _validatio
     };
 
     TWBootstrapViewStrategyBase.prototype.findLabelsRecursively = function findLabelsRecursively(currentElement, inputId, currentLabels, currentDepth) {
-      if (currentDepth === 5) {
+      if (currentDepth === 5 || currentLabels.length >= 1) {
         return;
       }
       if (currentElement.nodeName === 'LABEL' && (currentElement.attributes['for'] && currentElement.attributes['for'].value === inputId || !currentElement.attributes['for'])) {

--- a/dist/commonjs/strategies/twbootstrap-view-strategy.js
+++ b/dist/commonjs/strategies/twbootstrap-view-strategy.js
@@ -39,7 +39,7 @@ var TWBootstrapViewStrategyBase = (function (_ValidationViewStrategy) {
   };
 
   TWBootstrapViewStrategyBase.prototype.findLabelsRecursively = function findLabelsRecursively(currentElement, inputId, currentLabels, currentDepth) {
-    if (currentDepth === 5) {
+    if (currentDepth === 5 || currentLabels.length >= 1) {
       return;
     }
     if (currentElement.nodeName === 'LABEL' && (currentElement.attributes['for'] && currentElement.attributes['for'].value === inputId || !currentElement.attributes['for'])) {

--- a/dist/es6/strategies/twbootstrap-view-strategy.js
+++ b/dist/es6/strategies/twbootstrap-view-strategy.js
@@ -27,7 +27,7 @@ export class TWBootstrapViewStrategyBase extends ValidationViewStrategy {
   }
 
   findLabelsRecursively(currentElement, inputId, currentLabels, currentDepth) {
-    if (currentDepth === 5 || currentLabels.length == 1) {
+    if (currentDepth === 5 || currentLabels.length >= 1) {
       return;
     }
     if (currentElement.nodeName === 'LABEL' &&

--- a/dist/es6/strategies/twbootstrap-view-strategy.js
+++ b/dist/es6/strategies/twbootstrap-view-strategy.js
@@ -27,7 +27,7 @@ export class TWBootstrapViewStrategyBase extends ValidationViewStrategy {
   }
 
   findLabelsRecursively(currentElement, inputId, currentLabels, currentDepth) {
-    if (currentDepth === 5) {
+    if (currentDepth === 5 || currentLabels.length == 1) {
       return;
     }
     if (currentElement.nodeName === 'LABEL' &&

--- a/dist/system/strategies/twbootstrap-view-strategy.js
+++ b/dist/system/strategies/twbootstrap-view-strategy.js
@@ -43,7 +43,7 @@ System.register(['../validation-view-strategy'], function (_export) {
         };
 
         TWBootstrapViewStrategyBase.prototype.findLabelsRecursively = function findLabelsRecursively(currentElement, inputId, currentLabels, currentDepth) {
-          if (currentDepth === 5) {
+          if (currentDepth === 5 || currentLabels.length >= 1) {
             return;
           }
           if (currentElement.nodeName === 'LABEL' && (currentElement.attributes['for'] && currentElement.attributes['for'].value === inputId || !currentElement.attributes['for'])) {

--- a/src/strategies/twbootstrap-view-strategy.js
+++ b/src/strategies/twbootstrap-view-strategy.js
@@ -27,7 +27,7 @@ export class TWBootstrapViewStrategyBase extends ValidationViewStrategy {
   }
 
   findLabelsRecursively(currentElement, inputId, currentLabels, currentDepth) {
-    if (currentDepth === 5) {
+    if (currentDepth === 5 || currentLabels.length >= 1) {
       return;
     }
     if (currentElement.nodeName === 'LABEL' &&


### PR DESCRIPTION
Resubmitting now that it is properly built. This is needed to prevent adding the validation error multiple times to radio or checkbox labels. The first label in the form group is the label for the group. Each subsequent label might be wrapping the check/radio inputs and should not receive the message. 