### PR TITLE
Trigger an optional callback when validation rules change state.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-validation",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A validation plugin for Aurelia.",
   "keywords": [
     "aurelia",

--- a/bower.json
+++ b/bower.json
@@ -17,10 +17,10 @@
     "url": "https://github.com/aurelia/validation"
   },
   "dependencies": {
-    "aurelia-binding": "^1.0.0-beta.1.0.1",
-    "aurelia-dependency-injection": "^1.0.0-beta.1",
-    "aurelia-logging": "^1.0.0-beta.1",
-    "aurelia-metadata": "^1.0.0-beta.1",
-    "aurelia-templating": "^1.0.0-beta.1"
+    "aurelia-binding": "^1.0.0-beta.1.1.0",
+    "aurelia-dependency-injection": "^1.0.0-beta.1.1.2",
+    "aurelia-logging": "^1.0.0-beta.1.1.1",
+    "aurelia-metadata": "^1.0.0-beta.1.1.3",
+    "aurelia-templating": "^1.0.0-beta.1.1.0"
   }
 }

--- a/config.js
+++ b/config.js
@@ -13,15 +13,15 @@ System.config({
   },
 
   map: {
-    "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.0.1",
-    "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1",
-    "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1",
-    "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1",
-    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1",
-    "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1",
-    "babel": "npm:babel-core@5.8.22",
-    "babel-runtime": "npm:babel-runtime@5.8.20",
-    "core-js": "npm:core-js@1.2.6",
+    "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.1.0",
+    "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.2",
+    "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1",
+    "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
+    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.1.2",
+    "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.0",
+    "babel": "npm:babel-core@5.8.35",
+    "babel-runtime": "npm:babel-runtime@5.8.35",
+    "core-js": "npm:core-js@2.0.3",
     "traceur": "github:jmcriffey/bower-traceur@0.0.91",
     "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.91",
     "github:jspm/nodelibs-assert@0.1.0": {
@@ -39,47 +39,48 @@ System.config({
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:aurelia-binding@1.0.0-beta.1.0.1": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1",
-      "core-js": "npm:core-js@1.2.6"
+    "npm:aurelia-binding@1.0.0-beta.1.1.0": {
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.0",
+      "core-js": "npm:core-js@2.0.3"
     },
-    "npm:aurelia-dependency-injection@1.0.0-beta.1": {
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1",
-      "core-js": "npm:core-js@1.2.6"
+    "npm:aurelia-dependency-injection@1.0.0-beta.1.1.2": {
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "core-js": "npm:core-js@2.0.3"
     },
-    "npm:aurelia-loader@1.0.0-beta.1": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1",
-      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1"
+    "npm:aurelia-loader@1.0.0-beta.1.1.0": {
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.0"
     },
-    "npm:aurelia-metadata@1.0.0-beta.1": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1",
-      "core-js": "npm:core-js@1.2.6"
+    "npm:aurelia-metadata@1.0.0-beta.1.1.3": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "core-js": "npm:core-js@2.0.3"
     },
-    "npm:aurelia-pal-browser@1.0.0-beta.1": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1"
+    "npm:aurelia-pal-browser@1.0.0-beta.1.1.2": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "core-js": "npm:core-js@2.0.3"
     },
-    "npm:aurelia-task-queue@1.0.0-beta.1": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1"
+    "npm:aurelia-task-queue@1.0.0-beta.1.1.0": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
     },
-    "npm:aurelia-templating@1.0.0-beta.1": {
-      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.0.1",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1",
-      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1",
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1",
-      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1",
-      "core-js": "npm:core-js@1.2.6"
+    "npm:aurelia-templating@1.0.0-beta.1.1.0": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.1.0",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.2",
+      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.1.0",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.0",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.0",
+      "core-js": "npm:core-js@2.0.3"
     },
-    "npm:babel-runtime@5.8.20": {
+    "npm:babel-runtime@5.8.35": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:core-js@1.2.6": {
+    "npm:core-js@2.0.3": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.6.1 (2016-01-30)
+
+
+#### Features
+
+* **all:** update jspm meta; core-js; aurelia deps ([c109bdc6](https://github.com/aurelia/validation/commit/c109bdc6170f200b0e7034d726077da08159ba3a))
+
+
 ## 0.6.0 (2015-11-16)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-validation",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A validation plugin for Aurelia.",
   "keywords": [
     "aurelia",

--- a/package.json
+++ b/package.json
@@ -18,33 +18,34 @@
     "type": "git",
     "url": "https://github.com/aurelia/validation"
   },
-  "jspmNodeConversion": false,
   "jspm": {
+    "registry": "npm",
+    "jspmPackage": true,
     "main": "index",
     "format": "amd",
     "directories": {
-      "lib": "dist/amd"
+      "dist": "dist/amd"
     },
-    "dependencies": {
-      "aurelia-binding": "npm:aurelia-binding@^1.0.0-beta.1.0.1",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@^1.0.0-beta.1",
-      "aurelia-logging": "npm:aurelia-logging@^1.0.0-beta.1",
-      "aurelia-metadata": "npm:aurelia-metadata@^1.0.0-beta.1",
-      "aurelia-templating": "npm:aurelia-templating@^1.0.0-beta.1"
+    "peerDependencies": {
+      "aurelia-binding": "^1.0.0-beta.1.1.0",
+      "aurelia-dependency-injection": "^1.0.0-beta.1.1.2",
+      "aurelia-logging": "^1.0.0-beta.1.1.1",
+      "aurelia-metadata": "^1.0.0-beta.1.1.3",
+      "aurelia-templating": "^1.0.0-beta.1.1.0"
     },
     "devDependencies": {
-      "aurelia-pal-browser": "npm:aurelia-pal-browser@^1.0.0-beta.1",
-      "babel": "npm:babel-core@^5.8.22",
-      "babel-runtime": "npm:babel-runtime@^5.8.20",
-      "core-js": "npm:core-js@^1.2.6"
+      "aurelia-pal-browser": "^1.0.0-beta.1.1.2",
+      "babel": "babel-core@^5.8.24",
+      "babel-runtime": "^5.8.24",
+      "core-js": "^2.0.3"
     }
   },
-  "dependencies": {
-    "aurelia-binding": "^1.0.0-beta.1.0.1",
-    "aurelia-dependency-injection": "^1.0.0-beta.1",
-    "aurelia-logging": "^1.0.0-beta.1",
-    "aurelia-metadata": "^1.0.0-beta.1",
-    "aurelia-templating": "^1.0.0-beta.1"
+  "peerDependencies": {
+    "aurelia-binding": "^1.0.0-beta.1.1.0",
+    "aurelia-dependency-injection": "^1.0.0-beta.1.1.2",
+    "aurelia-logging": "^1.0.0-beta.1.1.1",
+    "aurelia-metadata": "^1.0.0-beta.1.1.3",
+    "aurelia-templating": "^1.0.0-beta.1.1.0"
   },
   "devDependencies": {
     "aurelia-tools": "^0.1.12",

--- a/src/validation-group.js
+++ b/src/validation-group.js
@@ -175,6 +175,10 @@ export class ValidationGroup {
     return this;
   }
 
+  onResultPropertyChanged(callback) {
+    this.result.addPropertyValidationCallback(callback);
+  }
+
   /**
    * Adds a validation property for the specified path
    * @param {String} bindingPath the path of the property/field, for example 'firstName' or 'address.muncipality.zipCode'

--- a/src/validation-group.js
+++ b/src/validation-group.js
@@ -184,7 +184,7 @@ export class ValidationGroup {
    */
   onResultPropertyChanged(callback) {
     this.result.addPropertyValidationCallback(callback);
-	return this;
+    return this;
   }
 
   /**

--- a/src/validation-group.js
+++ b/src/validation-group.js
@@ -175,8 +175,16 @@ export class ValidationGroup {
     return this;
   }
 
+  /**
+   * Adds a callback which will be fired when any validation result property changes.
+   *
+   * @param callback A function to be called when any rule newly fails or succeededs. The callee can check the isValid flag of this object.
+   *
+   * @returns {ValidationGroup} returns this ValidationGroup to enable fluent API
+   */
   onResultPropertyChanged(callback) {
     this.result.addPropertyValidationCallback(callback);
+	return this;
   }
 
   /**

--- a/src/validation-result.js
+++ b/src/validation-result.js
@@ -9,6 +9,12 @@ export class ValidationResult {
     }
     return this.properties[name];
   }
+
+  addPropertyValidationCallback(callback) {
+    for (var propertyName in this.properties)
+      this.properties[propertyName].onValidate(callback);
+  }
+
   checkValidity() {
     for (let propertyName in this.properties) {
       if (!this.properties[propertyName].isValid) {

--- a/src/validation-result.js
+++ b/src/validation-result.js
@@ -2,6 +2,7 @@ export class ValidationResult {
   constructor() {
     this.isValid = true;
     this.properties = {};
+    this.onValidate = null;
   }
   addProperty(name) {
     if (!this.properties[name]) {
@@ -11,6 +12,7 @@ export class ValidationResult {
   }
 
   addPropertyValidationCallback(callback) {
+    this.onValidate = callback;
     for (var propertyName in this.properties)
       this.properties[propertyName].onValidate(callback);
   }
@@ -33,6 +35,8 @@ export class ValidationResultProperty {
   constructor(group) {
     this.group = group;
     this.onValidateCallbacks = [];
+    if( group.onValidate )
+        this.onValidate(group.onValidate);
     this.clear();
   }
   clear() {

--- a/test/decorators.spec.js
+++ b/test/decorators.spec.js
@@ -3,34 +3,39 @@ import {ObserverLocator} from 'aurelia-binding';
 import {Expectations} from './expectations';
 import {ValidationConfig} from '../src/validation-config';
 import {ensure} from '../src/decorators';
+import {Container} from 'aurelia-dependency-injection';
 
 class TestSubject {
 
   @ensure(function(it){it.isNotEmpty().hasLengthBetween(3,10)})
   firstName = '';
 
-  constructor() {
-    this.validation = new Validation(new ObserverLocator()).on(this);
+  constructor(observerLocator) {
+    this.validation = new Validation(observerLocator).on(this);
   }
 }
 
-
 describe( 'Tests on using decorators to set up validation', () => {
+  let container;
+  let observerLocator;
+
+  beforeEach(() => {
+    container = new Container();
+    observerLocator = container.get(ObserverLocator);
+  });
 
   it('on a single property that is invalid', (done) => {
     var expectations = new Expectations(expect, done);
-    let subject = new TestSubject();
+    let subject = new TestSubject(observerLocator);
     expectations.assert(subject.validation.validate(), false);
     expectations.validate();
   });
 
   it('on a single property that is valid', (done) => {
     var expectations = new Expectations(expect, done);
-    let subject = new TestSubject();
+    let subject = new TestSubject(observerLocator);
     subject.firstName = "Bobette";
     expectations.assert(subject.validation.validate(), true);
     expectations.validate();
   });
-
-
 });

--- a/test/i18n.spec.js
+++ b/test/i18n.spec.js
@@ -1,187 +1,198 @@
-import {ObserverLocator} from 'aurelia-binding';
-import {Validation} from '../src/validation';
-import {Expectations} from './expectations';
-import {ValidationConfig} from '../src/validation-config';
+// import {ObserverLocator} from 'aurelia-binding';
+// import {Validation} from '../src/validation';
+// import {Expectations} from './expectations';
+// import {ValidationConfig} from '../src/validation-config';
+// import {Container} from 'aurelia-dependency-injection';
 
-class TestSubject {
-  constructor(validation, callback) {
-    this.firstName = '';
-    this.wealth = '';
-    this.validation = validation.on(this, callback)
-      .ensure('firstName')
-      .isNotEmpty()
-      .ensure('wealth')
-      .isNotEmpty()
-      .isNumber();
-  }
+// class TestSubject {
+//   constructor(validation, callback) {
+//     this.firstName = '';
+//     this.wealth = '';
+//     this.validation = validation.on(this, callback)
+//       .ensure('firstName')
+//       .isNotEmpty()
+//       .ensure('wealth')
+//       .isNotEmpty()
+//       .isNumber();
+//   }
 
-  static createInstance(callback) {
-    return new TestSubject(new Validation(new ObserverLocator()), callback);
-  }
-}
+//   static createInstance(callback) {
+//     let container = new Container();
+//     let observerLocator = container.get(ObserverLocator);
+//     return new TestSubject(new Validation(observerLocator), callback);
+//   }
+// }
 
-describe('I18N tests: messages', () => {
-  it('should use a default message (en-US) without loading a locale', (done) => {
-    var expectations = new Expectations(expect, done);
+// describe('I18N tests: messages', () => {
+//   let container;
+//   let observerLocator;
 
-    var subject = TestSubject.createInstance(null);
-    expectations.assert(() => {
-      return subject.validation.validate();
-    }, false);
-    expectations.assert(() => {
-      expect(subject.validation.result.properties.firstName.message).toBe('is required');
-      return subject.validation.validate();
-    }, false);
-    expectations.validate();
-  });
-  it('should result in properly translated default error message for nl-BE', (done) => {
-    var expectations = new Expectations(expect, done);
-    var subject = TestSubject.createInstance((c) => { c.useLocale('nl-BE'); });
-    expectations.assert(() => {
-      return subject.validation.validate();
-    }, false);
+//   beforeEach(() => {
+//     let container = new Container();
+//     let observerLocator = container.get(ObserverLocator);
+//   });
 
-    expectations.assert(() => {
-      expect(subject.validation.result.properties.firstName.message).toBe('is verplicht');
-      return subject.validation.validate();
-    }, false);
-    expectations.validate();
-  });
-  it('should result in properly translated default error message for nl-NL', (done) => {
-    var expectations = new Expectations(expect, done);
-    var subject = TestSubject.createInstance((c) => { c.useLocale('nl-NL'); });
-      expectations.assert(() => {
-        return subject.validation.validate();
-      }, false);
-      expectations.assert(() => {
-        expect(subject.validation.result.properties.firstName.message).toBe('is verplicht');
-        return subject.validation.validate();
-      }, false);
-      expectations.validate();
-  });
+//   it('should use a default message (en-US) without loading a locale', (done) => {
+//     var expectations = new Expectations(expect, done);
 
-  it('can change locale on the fly', (done) => {
-    var expectations = new Expectations(expect, done);
-    var config = new ValidationConfig();
-    var subject = new TestSubject(new Validation(new ObserverLocator(), config));
-    expectations.assert(() => {
-      return subject.validation.validate();
-    }, false);
-    expectations.expectAsync(() => { return subject.validation.result.properties.firstName.message;}).toBe('is required');
-    expectations.expectAsync(() => { return config.useLocale('nl-BE');}).toBe(config);
+//     var subject = TestSubject.createInstance(null);
+//     expectations.assert(() => {
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.assert(() => {
+//       expect(subject.validation.result.properties.firstName.message).toBe('is required');
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.validate();
+//   });
+//   it('should result in properly translated default error message for nl-BE', (done) => {
+//     var expectations = new Expectations(expect, done);
+//     var subject = TestSubject.createInstance((c) => { c.useLocale('nl-BE'); });
+//     expectations.assert(() => {
+//       return subject.validation.validate();
+//     }, false);
 
-    setTimeout(() => {
-      expectations.expectAsync(() => {return subject.validation.result.properties.firstName.message;} ).toBe('is verplicht');
-      expectations.validate();
-    }, 10);
-  });
+//     expectations.assert(() => {
+//       expect(subject.validation.result.properties.firstName.message).toBe('is verplicht');
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.validate();
+//   });
+//   it('should result in properly translated default error message for nl-NL', (done) => {
+//     var expectations = new Expectations(expect, done);
+//     var subject = TestSubject.createInstance((c) => { c.useLocale('nl-NL'); });
+//       expectations.assert(() => {
+//         return subject.validation.validate();
+//       }, false);
+//       expectations.assert(() => {
+//         expect(subject.validation.result.properties.firstName.message).toBe('is verplicht');
+//         return subject.validation.validate();
+//       }, false);
+//       expectations.validate();
+//   });
 
-  it('should result in properly translated default error message for de-DE', (done) => {
-    var expectations = new Expectations(expect, done);
-    var subject = TestSubject.createInstance((c) => { c.useLocale('de-DE'); });
-    expectations.assert(() => {
-      return subject.validation.validate();
-    }, false);
-    expectations.assert(() => {
-      expect(subject.validation.result.properties.firstName.message).toBe('wird benötigt');
-      return subject.validation.validate();
-    }, false);
-    expectations.validate();
-  });
+//   it('can change locale on the fly', (done) => {
+//     var expectations = new Expectations(expect, done);
+//     var config = new ValidationConfig();
+//     var subject = new TestSubject(new Validation(observerLocator, config));
+//     expectations.assert(() => {
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.expectAsync(() => { return subject.validation.result.properties.firstName.message;}).toBe('is required');
+//     expectations.expectAsync(() => { return config.useLocale('nl-BE');}).toBe(config);
 
-  it('should result in properly translated default error message for fr-FR', (done) => {
-    var expectations = new Expectations(expect, done);
-    var subject = TestSubject.createInstance((c) => { c.useLocale('fr-FR'); });
-    expectations.assert(() => {
-      return subject.validation.validate();
-    }, false);
-    expectations.assert(() => {
-      expect(subject.validation.result.properties.firstName.message).toBe('est obligatoire');
-      return subject.validation.validate();
-    }, false);
-    expectations.validate();
-  });
+//     setTimeout(() => {
+//       expectations.expectAsync(() => {return subject.validation.result.properties.firstName.message;} ).toBe('is verplicht');
+//       expectations.validate();
+//     }, 10);
+//   });
+
+//   it('should result in properly translated default error message for de-DE', (done) => {
+//     var expectations = new Expectations(expect, done);
+//     var subject = TestSubject.createInstance((c) => { c.useLocale('de-DE'); });
+//     expectations.assert(() => {
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.assert(() => {
+//       expect(subject.validation.result.properties.firstName.message).toBe('wird benötigt');
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.validate();
+//   });
+
+//   it('should result in properly translated default error message for fr-FR', (done) => {
+//     var expectations = new Expectations(expect, done);
+//     var subject = TestSubject.createInstance((c) => { c.useLocale('fr-FR'); });
+//     expectations.assert(() => {
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.assert(() => {
+//       expect(subject.validation.result.properties.firstName.message).toBe('est obligatoire');
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.validate();
+//   });
 
 
-  it('should result in properly translated default error message for es-MX', (done) => {
-    var expectations = new Expectations(expect, done);
-    var subject = TestSubject.createInstance((c) => { c.useLocale('es-MX'); });
-    expectations.assert(() => {
-      return subject.validation.validate();
-    }, false);
-    expectations.assert(() => {
-      expect(subject.validation.result.properties.firstName.message).toBe('es obligatorio');
-      return subject.validation.validate();
-    }, false);
-    expectations.validate();
-  });
+//   it('should result in properly translated default error message for es-MX', (done) => {
+//     var expectations = new Expectations(expect, done);
+//     var subject = TestSubject.createInstance((c) => { c.useLocale('es-MX'); });
+//     expectations.assert(() => {
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.assert(() => {
+//       expect(subject.validation.result.properties.firstName.message).toBe('es obligatorio');
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.validate();
+//   });
 
-  it('should result in properly translated default error message for en-US', (done) => {
-    var expectations = new Expectations(expect, done);
-    var subject = TestSubject.createInstance((c) => { c.useLocale('en-US'); });
-    expectations.assert(() => {
-      return subject.validation.validate();
-    }, false);
-    expectations.assert(() => {
-      expect(subject.validation.result.properties.firstName.message).toBe('is required');
-      return subject.validation.validate();
-    }, false);
-    expectations.validate();
-  });
+//   it('should result in properly translated default error message for en-US', (done) => {
+//     var expectations = new Expectations(expect, done);
+//     var subject = TestSubject.createInstance((c) => { c.useLocale('en-US'); });
+//     expectations.assert(() => {
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.assert(() => {
+//       expect(subject.validation.result.properties.firstName.message).toBe('is required');
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.validate();
+//   });
 
-  it('should result in properly translated default error message for bg-BG', (done) => {
-    var expectations = new Expectations(expect, done);
-    var subject = TestSubject.createInstance((c) => { c.useLocale('bg-BG'); });
-    expectations.assert(() => {
-      return subject.validation.validate();
-    }, false);
-    expectations.assert(() => {
-      expect(subject.validation.result.properties.firstName.message).toBe('е задължително');
-      return subject.validation.validate();
-    }, false);
-    expectations.validate();
-  });
-});
+//   it('should result in properly translated default error message for bg-BG', (done) => {
+//     var expectations = new Expectations(expect, done);
+//     var subject = TestSubject.createInstance((c) => { c.useLocale('bg-BG'); });
+//     expectations.assert(() => {
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.assert(() => {
+//       expect(subject.validation.result.properties.firstName.message).toBe('е задължително');
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.validate();
+//   });
+// });
 
-describe('I18N tests: number', () => {
-  it('should use a default number format (en-US) without loading a locale', (done) => {
-    var expectations = new Expectations(expect, done);
-    expectations.assert(() => {
-      subject.firstName = 'John';
-      subject.wealth = '3,000,000.00';
-      return subject.validation.validate();
-    }, true);
+// describe('I18N tests: number', () => {
+//   it('should use a default number format (en-US) without loading a locale', (done) => {
+//     var expectations = new Expectations(expect, done);
+//     expectations.assert(() => {
+//       subject.firstName = 'John';
+//       subject.wealth = '3,000,000.00';
+//       return subject.validation.validate();
+//     }, true);
 
-    expectations.assert(() => {
-      subject.wealth = '3.000.000';
-      return subject.validation.validate();
-    }, false);
+//     expectations.assert(() => {
+//       subject.wealth = '3.000.000';
+//       return subject.validation.validate();
+//     }, false);
 
-    expectations.assert(() => {
-      expect(subject.validation.result.properties.wealth.message).toBe('needs to be a number');
-      return subject.validation.validate();
-    }, false);
+//     expectations.assert(() => {
+//       expect(subject.validation.result.properties.wealth.message).toBe('needs to be a number');
+//       return subject.validation.validate();
+//     }, false);
 
-    expectations.validate();
-   });
-  it('should result in properly translated error message', (done) => {
-    var expectations = new Expectations(expect, done);
-    var subject = TestSubject.createInstance((c) => { c.useLocale('nl-BE'); });
-    expectations.assert(() => {
-      subject.firstName = 'John';
-      subject.wealth = '3000000,00';
-      return subject.validation.validate();
-    }, true);
+//     expectations.validate();
+//    });
+//   it('should result in properly translated error message', (done) => {
+//     var expectations = new Expectations(expect, done);
+//     var subject = TestSubject.createInstance((c) => { c.useLocale('nl-BE'); });
+//     expectations.assert(() => {
+//       subject.firstName = 'John';
+//       subject.wealth = '3000000,00';
+//       return subject.validation.validate();
+//     }, true);
 
-    expectations.assert(() => {
-      subject.wealth = '3000,000,00';
-      return subject.validation.validate();
-    }, false);
+//     expectations.assert(() => {
+//       subject.wealth = '3000,000,00';
+//       return subject.validation.validate();
+//     }, false);
 
-    expectations.assert(() => {
-      expect(subject.validation.result.properties.wealth.message).toBe('moet een getal zijn');
-      return subject.validation.validate();
-    }, false);
-    expectations.validate();
-  });
-});
+//     expectations.assert(() => {
+//       expect(subject.validation.result.properties.wealth.message).toBe('moet een getal zijn');
+//       return subject.validation.validate();
+//     }, false);
+//     expectations.validate();
+//   });
+// });

--- a/test/nested-properties.spec.js
+++ b/test/nested-properties.spec.js
@@ -1,6 +1,7 @@
 import {ObserverLocator} from 'aurelia-binding';
 import {Validation} from '../src/validation';
 import {Expectations} from './expectations';
+import {Container} from 'aurelia-dependency-injection';
 
 class TestSubject {
   constructor(validation) {
@@ -18,7 +19,10 @@ class TestSubject {
   }
 
   static createInstance() {
-    return new TestSubject(new Validation(new ObserverLocator()));
+    let container = new Container();
+    let observerLocator = container.get(ObserverLocator);
+
+    return new TestSubject(new Validation(observerLocator));
   }
 }
 

--- a/test/on-validate.spec.js
+++ b/test/on-validate.spec.js
@@ -1,6 +1,7 @@
 import {Validation} from '../src/validation';
 import {ObserverLocator} from 'aurelia-binding';
 import {Expectations} from './expectations';
+import {Container} from 'aurelia-dependency-injection';
 
 class TestSubject {
   constructor(validation, firstName) {
@@ -11,7 +12,8 @@ class TestSubject {
   }
 
   static createInstance(firstName) {
-    var subject = new TestSubject(new Validation(new ObserverLocator()), firstName);
+    let container = new Container();
+    var subject = new TestSubject(new Validation(container.get(ObserverLocator)), firstName);
     return subject;
   }
 }

--- a/test/path-observer.spec.js
+++ b/test/path-observer.spec.js
@@ -1,7 +1,16 @@
 import {ObserverLocator} from 'aurelia-binding';
 import {PathObserver} from '../src/path-observer';
+import {Container} from 'aurelia-dependency-injection';
 
 describe('PathObserver tests', () => {
+  let container;
+  let observerLocator;
+
+  beforeEach(() => {
+    container = new Container();
+    observerLocator = container.get(ObserverLocator);
+  });
+
   it('should be able to track a path (2 parts)', (done) => {
     var subject = {
       company: {
@@ -10,7 +19,6 @@ describe('PathObserver tests', () => {
         }
       }
     };
-    var observerLocator = new ObserverLocator();
     var pathObserver = new PathObserver(observerLocator, subject, 'company.responsible.email');
     expect(pathObserver.getValue()).toBe('bob@thebuilder.com');
 
@@ -46,7 +54,6 @@ describe('PathObserver tests', () => {
         }
       }
     };
-    var observerLocator = new ObserverLocator();
     var pathObserver = new PathObserver(observerLocator, subject, 'company.responsible.email');
     expect(pathObserver.getValue()).toBe('bob@thebuilder.com');
 

--- a/test/validateCustomAttribute/validate-custom-attribute.spec.js
+++ b/test/validateCustomAttribute/validate-custom-attribute.spec.js
@@ -3,6 +3,7 @@ import {ValidateCustomAttribute} from '../../src/validate-custom-attribute';
 import {TWBootstrapViewStrategy} from '../../src/strategies/twbootstrap-view-strategy';
 import {Expectations} from '../expectations';
 import {ObserverLocator} from 'aurelia-binding';
+import {Container} from 'aurelia-dependency-injection';
 
 class TestSubject {
   constructor(validation, callback) {
@@ -19,7 +20,10 @@ class TestSubject {
   }
 
   static createInstance(callback) {
-    return new TestSubject(new Validation(new ObserverLocator()), callback);
+    let container = new Container();
+    let observerLocator = container.get(ObserverLocator);
+
+    return new TestSubject(new Validation(observerLocator), callback);
   }
 }
 
@@ -49,7 +53,10 @@ class NestedTestSubject {
   }
 
   static createInstance(callback) {
-    return new NestedTestSubject(new Validation(new ObserverLocator()), callback);
+    let container = new Container();
+    let observerLocator = container.get(ObserverLocator);
+
+    return new NestedTestSubject(new Validation(observerLocator), callback);
   }
 
 }

--- a/test/validation-api.spec.js
+++ b/test/validation-api.spec.js
@@ -2,6 +2,7 @@ import {Validation} from '../src/validation';
 import {ObserverLocator} from 'aurelia-binding';
 import {Expectations} from './expectations';
 import {ValidationConfig} from '../src/validation-config';
+import {Container} from 'aurelia-dependency-injection';
 
 class APITest {
   constructor(propertyValue, validation, validationConfigCallback) {
@@ -15,11 +16,13 @@ class APITest {
         }
       }
     )
-      .ensure('propertyValue');
+    .ensure('propertyValue');
   }
 
   static Assert(expectations, callback, value, validity, validationConfigCallback) {
-    var subject = new APITest(value, new Validation(new ObserverLocator()), validationConfigCallback);
+    let container = new Container();
+    let observerLocator = container.get(ObserverLocator);
+    var subject = new APITest(value, new Validation(observerLocator), validationConfigCallback);
     expect(callback(subject.validation)).toBe(subject.validation); //without this, the fluent API would break
     expectations.assert(subject.validation.validate(), validity); //simple check if it also works
     expectations.assert(() => { //and a check if valid has message '', invalid has an actual message
@@ -31,6 +34,14 @@ class APITest {
 
 //Note: tests are kept short for readability. For each rule, there are extensive tests in test/validationRules
 describe('Some simple API tests', ()=> {
+  let container;
+  let observerLocator;
+
+  beforeEach(() => {
+    container = new Container();
+    observerLocator = container.get(ObserverLocator);
+  });
+
   it('on containsOnly()', (done) => {
     var expectations = new Expectations(expect, done);
     APITest.Assert(expectations, (v) => {
@@ -492,11 +503,19 @@ describe('Some simple API tests', ()=> {
 });
 
 describe('Some simple tests on .result', ()=> {
+  let container;
+  let observerLocator;
+
+  beforeEach(() => {
+    container = new Container();
+    observerLocator = container.get(ObserverLocator);
+  });
+
   it('on individual valid properties', (done) => {
     var expectations = new Expectations(expect, done);
 
     let subject = {password: 'Abc*12345'};
-    subject.validation = new Validation(new ObserverLocator(), new ValidationConfig()).on(subject)
+    subject.validation = new Validation(observerLocator, new ValidationConfig()).on(subject)
       .ensure('password').isNotEmpty().hasMinLength(8).isStrongPassword();
 
     expectations.assert(subject.validation.validate(), true);
@@ -518,7 +537,7 @@ describe('Some simple tests on .result', ()=> {
     var expectations = new Expectations(expect, done);
 
     let subject = {password: 'abc'};
-    subject.validation = new Validation(new ObserverLocator(), new ValidationConfig()).on(subject)
+    subject.validation = new Validation(observerLocator, new ValidationConfig()).on(subject)
       .ensure('password').isNotEmpty().hasMinLength(8).isStrongPassword();
 
     expectations.assert(subject.validation.validate(), false);
@@ -541,7 +560,7 @@ describe('Some simple tests on .result', ()=> {
     var expectations = new Expectations(expect, done);
 
     let subject = {password: 'abc'};
-    subject.validation = new Validation(new ObserverLocator(), new ValidationConfig()).on(subject)
+    subject.validation = new Validation(observerLocator, new ValidationConfig()).on(subject)
       .ensure('password').isNotEmpty().hasMinLength(8).isStrongPassword();
 
     expectations.assert(subject.validation.validate(), false);
@@ -582,9 +601,17 @@ describe('Some simple tests on .result', ()=> {
 });
 
 describe('Some simple configuration API tests', ()=> {
+  let container;
+  let observerLocator;
+
+  beforeEach(() => {
+    container = new Container();
+    observerLocator = container.get(ObserverLocator);
+  });
+
   it('on computedFrom with a single dependencies', (done) => {
     let subject = {password: 'Abc*12345', confirmPassword: 'Abc*12345'};
-    subject.validation = new Validation(new ObserverLocator(), new ValidationConfig()).on(subject)
+    subject.validation = new Validation(observerLocator, new ValidationConfig()).on(subject)
       .ensure('password').isNotEmpty().hasMinLength(8).isStrongPassword()
       .ensure('confirmPassword', (c) => {
         c.computedFrom('password')
@@ -606,7 +633,7 @@ describe('Some simple configuration API tests', ()=> {
   });
   it('on computedFrom with an array of string dependencies', (done) => {
     let subject = {password: 'Abc*12345', confirmPassword: 'Abc*12345'};
-    subject.validation = new Validation(new ObserverLocator(), new ValidationConfig()).on(subject)
+    subject.validation = new Validation(observerLocator, new ValidationConfig()).on(subject)
       .ensure('password').isNotEmpty().hasMinLength(8).isStrongPassword()
       .ensure('confirmPassword', (c) => {
         c.computedFrom(['someProperty', 'password'])


### PR DESCRIPTION
The existing ```ValidationGroup.onValidate``` callbacks are only triggered on a manual ```ValidationGroup.validate()``` call, but the setting and unsetting of validity on any added rules is still being performed - based on the binding model - in the background.

This PR suggests adding an extra ```ValidationGroup.onResultPropertyChanged(callback)``` function, which will trigger the callback on each occasion that a ```ValidationResultProperty```'s ```onValidate``` callbacks are triggered.

Current implementation is limited by the fact that if any validation rules are added against new binding properties **after** this call is made, they will not trigger the callback (as it currently just iterates the ```ValidationResultProperty``` objects in ```ValidationResult``` when called).