### PR TITLE
use aurelia-loader instead of hardcoded systemjs loader

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,6 +15,7 @@ System.config({
   map: {
     "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.1.0",
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.2",
+    "aurelia-loader": "github:aurelia/loader@1.0.0-beta.1.2.0",
     "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1",
     "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
     "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.1.2",
@@ -25,6 +26,10 @@ System.config({
     "core-js": "npm:core-js@2.0.3",
     "traceur": "github:jmcriffey/bower-traceur@0.0.91",
     "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.91",
+    "github:aurelia/loader@1.0.0-beta.1.2.0": {
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.0"
+    },
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
     },

--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -1,4 +1,4 @@
-define(['exports', './utilities', './validation-config', './validation-locale', './validation-result', './validation-rules', './validation', './validation-group', './validate-custom-attribute', './validation-view-strategy', './strategies/twbootstrap-view-strategy', './decorators'], function (exports, _utilities, _validationConfig, _validationLocale, _validationResult, _validationRules, _validation, _validationGroup, _validateCustomAttribute, _validationViewStrategy, _twbootstrapViewStrategy, _decorators) {
+define(['exports', './utilities', './validation-config', './validation-locale', './validation-result', './validation-rules', './validation', './validation-group', './validate-custom-attribute', './validation-view-strategy', './strategies/twbootstrap-view-strategy', './decorators', 'aurelia-loader'], function (exports, _utilities, _validationConfig, _validationLocale, _validationResult, _validationRules, _validation, _validationGroup, _validateCustomAttribute, _validationViewStrategy, _twbootstrapViewStrategy, _decorators, _aureliaLoader) {
   'use strict';
 
   Object.defineProperty(exports, "__esModule", {
@@ -84,6 +84,8 @@ define(['exports', './utilities', './validation-config', './validation-locale', 
       configCallback(_validation.Validation.defaults);
     }
     aurelia.singleton(_validationConfig.ValidationConfig, _validation.Validation.defaults);
+    var loader = aurelia.container.get(_aureliaLoader.Loader);
+    window.loader = window.loader || loader;
     return _validation.Validation.defaults.locale();
   }
 });

--- a/dist/amd/validation-locale.js
+++ b/dist/amd/validation-locale.js
@@ -80,7 +80,7 @@ define(['exports'], function (exports) {
           var locale = _this.instances.get(localeIdentifier);
           resolve(locale);
         } else {
-          System.import(basePath + localeIdentifier).then(function (resource) {
+          window.loader.loadModule(basePath + localeIdentifier).then(function (resource) {
             var locale = _this.addLocale(localeIdentifier, resource.data);
             resolve(locale);
           });

--- a/dist/aurelia-validation.js
+++ b/dist/aurelia-validation.js
@@ -1136,7 +1136,7 @@ class ValidationLocaleRepository  {
         let locale = this.instances.get(localeIdentifier);
         resolve(locale);
       } else {
-        System.import(basePath + localeIdentifier).then((resource) => {
+        window.loader.loadModule(basePath + localeIdentifier).then((resource) => {
           let locale = this.addLocale(localeIdentifier, resource.data);
           resolve(locale);
         });

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -110,11 +110,16 @@ Object.defineProperty(exports, 'ensure', {
   }
 });
 exports.configure = configure;
+
+var _aureliaLoader = require('aurelia-loader');
+
 function configure(aurelia, configCallback) {
   aurelia.globalResources('./validate-custom-attribute');
   if (configCallback !== undefined && typeof configCallback === 'function') {
     configCallback(_validation.Validation.defaults);
   }
   aurelia.singleton(_validationConfig.ValidationConfig, _validation.Validation.defaults);
+  var loader = aurelia.container.get(_aureliaLoader.Loader);
+  window.loader = window.loader || loader;
   return _validation.Validation.defaults.locale();
 }

--- a/dist/commonjs/validation-locale.js
+++ b/dist/commonjs/validation-locale.js
@@ -75,7 +75,7 @@ var ValidationLocaleRepository = function () {
         var locale = _this.instances.get(localeIdentifier);
         resolve(locale);
       } else {
-        System.import(basePath + localeIdentifier).then(function (resource) {
+        window.loader.loadModule(basePath + localeIdentifier).then(function (resource) {
           var locale = _this.addLocale(localeIdentifier, resource.data);
           resolve(locale);
         });

--- a/dist/es2015/index.js
+++ b/dist/es2015/index.js
@@ -10,6 +10,7 @@ export { ValidationViewStrategy } from './validation-view-strategy';
 export { TWBootstrapViewStrategy } from './strategies/twbootstrap-view-strategy';
 export { ensure } from './decorators';
 
+import { Loader } from 'aurelia-loader';
 import { ValidationConfig } from './validation-config';
 import { Validation } from './validation';
 
@@ -19,5 +20,7 @@ export function configure(aurelia, configCallback) {
     configCallback(Validation.defaults);
   }
   aurelia.singleton(ValidationConfig, Validation.defaults);
+  const loader = aurelia.container.get(Loader);
+  window.loader = window.loader || loader;
   return Validation.defaults.locale();
 }

--- a/dist/es2015/validation-locale.js
+++ b/dist/es2015/validation-locale.js
@@ -55,7 +55,7 @@ let ValidationLocaleRepository = class ValidationLocaleRepository {
         let locale = this.instances.get(localeIdentifier);
         resolve(locale);
       } else {
-        System.import(basePath + localeIdentifier).then(resource => {
+        window.loader.loadModule(basePath + localeIdentifier).then(resource => {
           let locale = this.addLocale(localeIdentifier, resource.data);
           resolve(locale);
         });

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-System.register(['./utilities', './validation-config', './validation-locale', './validation-result', './validation-rules', './validation', './validation-group', './validate-custom-attribute', './validation-view-strategy', './strategies/twbootstrap-view-strategy', './decorators'], function (_export, _context) {
-  var ValidationConfig, Validation;
+System.register(['./utilities', './validation-config', './validation-locale', './validation-result', './validation-rules', './validation', './validation-group', './validate-custom-attribute', './validation-view-strategy', './strategies/twbootstrap-view-strategy', './decorators', 'aurelia-loader'], function (_export, _context) {
+  var Loader, ValidationConfig, Validation;
   return {
     setters: [function (_utilities) {
       var _exportObj = {};
@@ -66,6 +66,8 @@ System.register(['./utilities', './validation-config', './validation-locale', '.
       _exportObj11.ensure = _decorators.ensure;
 
       _export(_exportObj11);
+    }, function (_aureliaLoader) {
+      Loader = _aureliaLoader.Loader;
     }],
     execute: function () {
       function configure(aurelia, configCallback) {
@@ -74,6 +76,8 @@ System.register(['./utilities', './validation-config', './validation-locale', '.
           configCallback(Validation.defaults);
         }
         aurelia.singleton(ValidationConfig, Validation.defaults);
+        var loader = aurelia.container.get(Loader);
+        window.loader = window.loader || loader;
         return Validation.defaults.locale();
       }
 

--- a/dist/system/validation-locale.js
+++ b/dist/system/validation-locale.js
@@ -83,7 +83,7 @@ System.register([], function (_export, _context) {
               var locale = _this.instances.get(localeIdentifier);
               resolve(locale);
             } else {
-              System.import(basePath + localeIdentifier).then(function (resource) {
+              window.loader.loadModule(basePath + localeIdentifier).then(function (resource) {
                 var locale = _this.addLocale(localeIdentifier, resource.data);
                 resolve(locale);
               });

--- a/dist/temp/aurelia-validation.js
+++ b/dist/temp/aurelia-validation.js
@@ -1078,7 +1078,7 @@ var ValidationLocaleRepository = function () {
         var locale = _this10.instances.get(localeIdentifier);
         resolve(locale);
       } else {
-        System.import(basePath + localeIdentifier).then(function (resource) {
+        window.loader.loadModule(basePath + localeIdentifier).then(function (resource) {
           var locale = _this10.addLocale(localeIdentifier, resource.data);
           resolve(locale);
         });

--- a/package.json
+++ b/package.json
@@ -20,22 +20,15 @@
   },
   "jspm": {
     "registry": "npm",
-    "jspmPackage": true,
     "main": "index",
     "format": "amd",
     "directories": {
       "dist": "dist/amd"
     },
-    "peerDependencies": {
-      "aurelia-binding": "^1.0.0-beta.1.1.0",
-      "aurelia-dependency-injection": "^1.0.0-beta.1.1.2",
-      "aurelia-logging": "^1.0.0-beta.1.1.1",
-      "aurelia-metadata": "^1.0.0-beta.1.1.3",
-      "aurelia-templating": "^1.0.0-beta.1.1.0"
-    },
     "dependencies": {
       "aurelia-binding": "^1.0.0-beta.1.1.0",
       "aurelia-dependency-injection": "^1.0.0-beta.1.1.2",
+      "aurelia-loader": "^1.0.0-beta.1.2.0",
       "aurelia-logging": "^1.0.0-beta.1.1.1",
       "aurelia-metadata": "^1.0.0-beta.1.1.3",
       "aurelia-templating": "^1.0.0-beta.1.1.0"
@@ -47,13 +40,6 @@
       "babel-runtime": "^5.8.24",
       "core-js": "^2.0.3"
     }
-  },
-  "dependencies": {
-    "aurelia-binding": "^1.0.0-beta.1.1.0",
-    "aurelia-dependency-injection": "^1.0.0-beta.1.1.2",
-    "aurelia-logging": "^1.0.0-beta.1.1.1",
-    "aurelia-metadata": "^1.0.0-beta.1.1.3",
-    "aurelia-templating": "^1.0.0-beta.1.1.0"
   },
   "devDependencies": {
     "aurelia-tools": "^0.1.20",

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export {ValidationViewStrategy} from './validation-view-strategy';
 export {TWBootstrapViewStrategy} from './strategies/twbootstrap-view-strategy';
 export {ensure} from './decorators';
 
+import {Loader} from 'aurelia-loader';
 import {ValidationConfig} from './validation-config';
 import {Validation} from './validation';
 
@@ -19,5 +20,7 @@ export function configure(aurelia, configCallback) {
     configCallback(Validation.defaults);
   }
   aurelia.singleton(ValidationConfig, Validation.defaults);
+  const loader = aurelia.container.get(Loader);
+  window.loader = window.loader || loader;
   return Validation.defaults.locale();
 }

--- a/src/validation-locale.js
+++ b/src/validation-locale.js
@@ -55,7 +55,7 @@ class ValidationLocaleRepository  {
         let locale = this.instances.get(localeIdentifier);
         resolve(locale);
       } else {
-        System.import(basePath + localeIdentifier).then((resource) => {
+        window.loader.loadModule(basePath + localeIdentifier).then((resource) => {
           let locale = this.addLocale(localeIdentifier, resource.data);
           resolve(locale);
         });


### PR DESCRIPTION
This PR attempts to fix #226, but comes with some caveats - if you guys (@EisenbergEffect, feel free to chime in here) have any suggestions to improve this, I'm more than happy to help, but given the architecture of this module these are the best solutions I could come up with given my somewhat limited understanding.

1. A new `window` global (`window.loader`) has been introduced in `index.js` because there seems to be no straightforward way of getting a singleton instance of `Loader` inside `ValidationLocaleRepository` using DI.

2. The `dependencies` section of `package.json` **has been removed** - I don't really understand why there are double dependency declarations (npm and jspm via npm) here? But I've found that whenever dependencies are declared there, ` aurelia.container.get(Loader)` gives me a fresh (non instantiated and useless) `Loader` instance, while when dependencies are only declared within the `jspm` area, I get the expected DI'd instance. **I'd really like to understand what's going on here. If someone can enlighten me I'd greatly appreciate it.**

3. A test case (`on using decorators to set up validation on a single property that is valid`) is failing, but it fails on master also.

Thanks!

P.S. I will add (thanks @stoffeastrom!) for this to work with webpack, the following configuration in `webpack.config.js` is required:

```
plugins: [
    new AureliaWebpackPlugin({
      includeSubModules: [
        { moduleId: "aurelia-validation" }
      ]
    })
  ]
```