### PR TITLE
Fixing IE 11 issues

### DIFF
--- a/dist/amd/validate-custom-attribute.js
+++ b/dist/amd/validate-custom-attribute.js
@@ -39,7 +39,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating'], functi
 
       var viewStrategy = this.value.config.getViewStrategy();
       var validationProperty = viewStrategy.getValidationProperty(this.value, currentElement);
-      var children = currentElement.children;
+      var children = currentElement.children || currentElement.childNodes;
       this.viewStrategy = viewStrategy;
       if (validationProperty !== null && validationProperty !== undefined) {
         this.viewStrategy.prepareElement(validationProperty, currentElement);
@@ -48,6 +48,7 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-templating'], functi
         });
       }
       for (var i = 0; i < children.length; i++) {
+        if (children[i].nodeType == 3) continue;
         this.subscribeChangedHandlers(children[i]);
       }
     };

--- a/dist/aurelia-validation.js
+++ b/dist/aurelia-validation.js
@@ -242,7 +242,7 @@ export class ValidateCustomAttribute {
   subscribeChangedHandlers(currentElement) {
     let viewStrategy = this.value.config.getViewStrategy();
     let validationProperty = viewStrategy.getValidationProperty(this.value, currentElement);
-    let children = currentElement.children;
+    let children = currentElement.children || currentElement.childNodes;
     this.viewStrategy = viewStrategy;
     if (validationProperty !== null && validationProperty !== undefined) {
       this.viewStrategy.prepareElement(validationProperty, currentElement);
@@ -253,6 +253,7 @@ export class ValidateCustomAttribute {
       );
     }
     for (let i = 0; i < children.length; i++) {
+      if (children[i].nodeType == 3) continue;
       this.subscribeChangedHandlers(children[i]);
     }
   }

--- a/dist/commonjs/validate-custom-attribute.js
+++ b/dist/commonjs/validate-custom-attribute.js
@@ -38,7 +38,7 @@ var ValidateCustomAttribute = exports.ValidateCustomAttribute = (_dec = (0, _aur
 
     var viewStrategy = this.value.config.getViewStrategy();
     var validationProperty = viewStrategy.getValidationProperty(this.value, currentElement);
-    var children = currentElement.children;
+    var children = currentElement.children || currentElement.childNodes;
     this.viewStrategy = viewStrategy;
     if (validationProperty !== null && validationProperty !== undefined) {
       this.viewStrategy.prepareElement(validationProperty, currentElement);
@@ -47,6 +47,7 @@ var ValidateCustomAttribute = exports.ValidateCustomAttribute = (_dec = (0, _aur
       });
     }
     for (var i = 0; i < children.length; i++) {
+      if (children[i].nodeType == 3) continue;
       this.subscribeChangedHandlers(children[i]);
     }
   };

--- a/dist/es2015/validate-custom-attribute.js
+++ b/dist/es2015/validate-custom-attribute.js
@@ -22,7 +22,7 @@ export let ValidateCustomAttribute = (_dec = customAttribute('validate'), _dec2 
   subscribeChangedHandlers(currentElement) {
     let viewStrategy = this.value.config.getViewStrategy();
     let validationProperty = viewStrategy.getValidationProperty(this.value, currentElement);
-    let children = currentElement.children;
+    let children = currentElement.children || currentElement.childNodes;
     this.viewStrategy = viewStrategy;
     if (validationProperty !== null && validationProperty !== undefined) {
       this.viewStrategy.prepareElement(validationProperty, currentElement);
@@ -31,6 +31,7 @@ export let ValidateCustomAttribute = (_dec = customAttribute('validate'), _dec2 
       });
     }
     for (let i = 0; i < children.length; i++) {
+      if (children[i].nodeType == 3) continue;
       this.subscribeChangedHandlers(children[i]);
     }
   }

--- a/dist/system/validate-custom-attribute.js
+++ b/dist/system/validate-custom-attribute.js
@@ -41,7 +41,7 @@ System.register(['aurelia-dependency-injection', 'aurelia-templating'], function
 
           var viewStrategy = this.value.config.getViewStrategy();
           var validationProperty = viewStrategy.getValidationProperty(this.value, currentElement);
-          var children = currentElement.children;
+          var children = currentElement.children || currentElement.childNodes;
           this.viewStrategy = viewStrategy;
           if (validationProperty !== null && validationProperty !== undefined) {
             this.viewStrategy.prepareElement(validationProperty, currentElement);
@@ -50,6 +50,7 @@ System.register(['aurelia-dependency-injection', 'aurelia-templating'], function
             });
           }
           for (var i = 0; i < children.length; i++) {
+            if (children[i].nodeType == 3) continue;
             this.subscribeChangedHandlers(children[i]);
           }
         };

--- a/dist/temp/aurelia-validation.js
+++ b/dist/temp/aurelia-validation.js
@@ -309,7 +309,7 @@ var ValidateCustomAttribute = exports.ValidateCustomAttribute = (_dec = (0, _aur
 
     var viewStrategy = this.value.config.getViewStrategy();
     var validationProperty = viewStrategy.getValidationProperty(this.value, currentElement);
-    var children = currentElement.children;
+    var children = currentElement.children || currentElement.childNodes;
     this.viewStrategy = viewStrategy;
     if (validationProperty !== null && validationProperty !== undefined) {
       this.viewStrategy.prepareElement(validationProperty, currentElement);
@@ -318,6 +318,7 @@ var ValidateCustomAttribute = exports.ValidateCustomAttribute = (_dec = (0, _aur
       });
     }
     for (var i = 0; i < children.length; i++) {
+      if (children[i].nodeType == 3) continue;
       this.subscribeChangedHandlers(children[i]);
     }
   };

--- a/src/validate-custom-attribute.js
+++ b/src/validate-custom-attribute.js
@@ -23,7 +23,7 @@ export class ValidateCustomAttribute {
   subscribeChangedHandlers(currentElement) {
     let viewStrategy = this.value.config.getViewStrategy();
     let validationProperty = viewStrategy.getValidationProperty(this.value, currentElement);
-    let children = currentElement.children;
+    let children = currentElement.children || currentElement.childNodes;
     this.viewStrategy = viewStrategy;
     if (validationProperty !== null && validationProperty !== undefined) {
       this.viewStrategy.prepareElement(validationProperty, currentElement);
@@ -34,6 +34,7 @@ export class ValidateCustomAttribute {
       );
     }
     for (let i = 0; i < children.length; i++) {
+      if (children[i].nodeType == 3) continue;
       this.subscribeChangedHandlers(children[i]);
     }
   }


### PR DESCRIPTION
Fixed an issue with SVG elements inside forms on IE 11.

I found an error in "subscribeChangedHandlers" of ValidateCustomAttribute class.

On IE 11 if form contains SVG element i.e.

`<form class="postcode-search__form" role="form" autocomplete="on" submit.delegate="submit()" validate.bind="validation">
        <div class="postcode-search__input validation-item">
            <input type="text" value.bind="postcode | upperCase" class="" name="zip|postal|post.*code|pcode|^1z$" placeholder="Search by postcode" title="Search by postcode" aria-required="true" autofocus>
        </div>
        <button type="submit" class="postcode-search__button btn btn--primary">Search
            <svg class="icon icon-search btn__icon"><use xlink:href="#icon-search"></use></svg>
        </button>
    </form>`

The problem:

`let children = currentElement.children` will be undefined, which completly breaks the plugin.

The fix: 

`let children = currentElement.children || currentElement.childNodes;`

`for (let i = 0; i < children.length; i++) {
      if (children[i].nodeType == 3) continue;
      this.subscribeChangedHandlers(children[i]);
    }
`