### PR TITLE
fix(loader): switch to using apps loader

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,16 +13,18 @@ System.config({
   },
 
   map: {
-    "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.1.0",
-    "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.2",
-    "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1",
-    "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
-    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.1.2",
-    "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0-beta.1.0.6",
-    "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.1.0",
-    "babel": "npm:babel-core@5.8.35",
-    "babel-runtime": "npm:babel-runtime@5.8.35",
-    "core-js": "npm:core-js@2.0.3",
+    "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.1",
+    "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0",
+    "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.2.0",
+    "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
+    "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
+    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.2.0",
+    "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0-beta.1.1.1",
+    "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.0",
+    "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.1",
+    "babel": "npm:babel-core@5.8.38",
+    "babel-runtime": "npm:babel-runtime@5.8.38",
+    "core-js": "npm:core-js@2.2.2",
     "traceur": "github:jmcriffey/bower-traceur@0.0.91",
     "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.91",
     "github:jspm/nodelibs-assert@0.1.0": {
@@ -40,51 +42,46 @@ System.config({
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:aurelia-binding@1.0.0-beta.1.1.0": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.0",
-      "core-js": "npm:core-js@2.0.3"
+    "npm:aurelia-binding@1.0.0-beta.1.3.1": {
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.0"
     },
-    "npm:aurelia-dependency-injection@1.0.0-beta.1.1.2": {
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
-      "core-js": "npm:core-js@2.0.3"
+    "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0": {
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
     },
-    "npm:aurelia-loader@1.0.0-beta.1.1.0": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
-      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.0"
+    "npm:aurelia-loader@1.0.0-beta.1.2.0": {
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.1"
     },
-    "npm:aurelia-metadata@1.0.0-beta.1.1.3": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
-      "core-js": "npm:core-js@2.0.3"
+    "npm:aurelia-metadata@1.0.0-beta.1.2.0": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
     },
-    "npm:aurelia-pal-browser@1.0.0-beta.1.1.2": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
-      "core-js": "npm:core-js@2.0.3"
+    "npm:aurelia-pal-browser@1.0.0-beta.1.2.0": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
     },
-    "npm:aurelia-polyfills@1.0.0-beta.1.0.6": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
+    "npm:aurelia-polyfills@1.0.0-beta.1.1.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
     },
-    "npm:aurelia-task-queue@1.0.0-beta.1.1.0": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1"
+    "npm:aurelia-task-queue@1.0.0-beta.1.2.0": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
     },
-    "npm:aurelia-templating@1.0.0-beta.1.1.0": {
-      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.1.0",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.2",
-      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.1.0",
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
-      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.0",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.1.0",
-      "core-js": "npm:core-js@2.0.3"
+    "npm:aurelia-templating@1.0.0-beta.1.2.1": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.1",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0",
+      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.2.0",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.1",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.0"
     },
-    "npm:babel-runtime@5.8.35": {
+    "npm:babel-runtime@5.8.38": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:core-js@2.0.3": {
+    "npm:core-js@2.2.2": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dependencies": {
       "aurelia-binding": "^1.0.0-beta.1.1.0",
       "aurelia-dependency-injection": "^1.0.0-beta.1.1.2",
+      "aurelia-loader": "^1.0.0-beta.1.2.0",
       "aurelia-logging": "^1.0.0-beta.1.1.1",
       "aurelia-metadata": "^1.0.0-beta.1.1.3",
       "aurelia-templating": "^1.0.0-beta.1.1.0"
@@ -43,6 +44,7 @@
     "devDependencies": {
       "aurelia-pal-browser": "^1.0.0-beta.1.1.2",
       "aurelia-polyfills": "^1.0.0-beta.1.0.6",
+      "aurelia-task-queue": "^1.0.0-beta.1.2.0",
       "babel": "babel-core@^5.8.24",
       "babel-runtime": "^5.8.24",
       "core-js": "^2.0.3"

--- a/src/validation-locale.js
+++ b/src/validation-locale.js
@@ -35,6 +35,9 @@ export class ValidationLocale {
   }
 }
 
+import {Container} from 'aurelia-dependency-injection';
+import {Loader} from 'aurelia-loader';
+
 class ValidationLocaleRepository  {
   constructor() {
     this.default = null;
@@ -55,7 +58,8 @@ class ValidationLocaleRepository  {
         let locale = this.instances.get(localeIdentifier);
         resolve(locale);
       } else {
-        System.import(basePath + localeIdentifier).then((resource) => {
+        let loader = Container.instance.get(Loader);
+        loader.loadModule(basePath + localeIdentifier).then((resource) => {
           let locale = this.addLocale(localeIdentifier, resource.data);
           resolve(locale);
         });
@@ -71,4 +75,5 @@ class ValidationLocaleRepository  {
     return instance;
   }
 }
+
 ValidationLocale.Repository = new ValidationLocaleRepository();


### PR DESCRIPTION
Fixes #226 when the loader was previously using System.js to load
instead of the app-wide loader.  Temporarily uses the global container
to get the app loader and use that instead to load the module.