### PR TITLE
Add proper resources to package.json for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,5 +103,14 @@
     "vinyl": "^1.1.1",
     "vinyl-paths": "^2.1.0",
     "yargs": "^4.7.1"
+  },
+  "aurelia": {
+    "build": {
+      "resources": [
+        "aurelia-validation/validation-renderer-custom-attribute",
+        "aurelia-validation/validation-errors-custom-attribute",
+        "aurelia-validation/validate-binding-behavior"
+      ]
+    }
   }
 }


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/aurelia/webpack-plugin/issues/48) on `aurelia-webpack-plugin` where resources aren't declared in the `package.json` and thus not available at build time. 