### PR TITLE
feat(validation-controller): skip validation on properties of null objects

### DIFF
--- a/src/property-info.js
+++ b/src/property-info.js
@@ -8,13 +8,8 @@ import {
 
 function getObject(expression, objectExpression, source) {
   let value = objectExpression.evaluate(source);
-  if (value !== null && (typeof value === 'object' || typeof value === 'function')) {
+  if (value === null || value === undefined || typeof value === 'object' || typeof value === 'function') {
     return value;
-  }
-  if (value === null) {
-    value = 'null';
-  } else if (value === undefined) {
-    value = 'undefined';
   }
   throw new Error(`The '${objectExpression}' part of '${expression}' evaluates to ${value} instead of an object.`);
 }

--- a/src/validation-controller.js
+++ b/src/validation-controller.js
@@ -118,8 +118,10 @@ export class ValidationController {
   _validateBinding(binding) {
     const { target, rules, errors } = this.bindings.get(binding);
     const { object, property } = getPropertyInfo(binding.sourceExpression, binding.source);
-    const newErrors = this.validator.validateProperty(object, property, rules);
-    this._updateErrors(errors, newErrors, target);
+    if (object) {
+        const newErrors = this.validator.validateProperty(object, property, rules);
+        this._updateErrors(errors, newErrors, target);
+    }
     return errors;
   }
 


### PR DESCRIPTION
When binding with dot-notation, skip validation of nested properties if the owner object is `null` or `undefined` instead of throwing an error.

Closes https://github.com/aurelia/validation/issues/277.