### PR TITLE
feat(validation-controller): add support for validation dependency

### DIFF
--- a/src/aurelia-validation.js
+++ b/src/aurelia-validation.js
@@ -6,6 +6,9 @@ export {ValidationErrorsCustomAttribute} from './validation-errors-custom-attrib
 export {ValidationRendererCustomAttribute} from './validation-renderer-custom-attribute';
 export {validationRenderer} from './validation-renderer';
 export {Validator} from './validator';
+export {ValidationRule} from './validation-rule';
+export {RulesContainer} from './rules-container';
+export {metadataKey} from './metadata-key';
 
 export function configure(config) {
   config.globalResources(

--- a/src/property-info.js
+++ b/src/property-info.js
@@ -8,13 +8,8 @@ import {
 
 function getObject(expression, objectExpression, source) {
   let value = objectExpression.evaluate(source);
-  if (value !== null && (typeof value === 'object' || typeof value === 'function')) {
+  if (value === null || value === undefined || typeof value === 'object' || typeof value === 'function') {
     return value;
-  }
-  if (value === null) {
-    value = 'null';
-  } else if (value === undefined) {
-    value = 'undefined';
   }
   throw new Error(`The '${objectExpression}' part of '${expression}' evaluates to ${value} instead of an object.`);
 }

--- a/src/validation-controller.js
+++ b/src/validation-controller.js
@@ -118,8 +118,10 @@ export class ValidationController {
   _validateBinding(binding) {
     const { target, rules, errors } = this.bindings.get(binding);
     const { object, property } = getPropertyInfo(binding.sourceExpression, binding.source);
-    const newErrors = this.validator.validateProperty(object, property, rules);
-    this._updateErrors(errors, newErrors, target);
+    if (object) {
+        const newErrors = this.validator.validateProperty(object, property, rules);
+        this._updateErrors(errors, newErrors, target);
+    }
     return errors;
   }
 


### PR DESCRIPTION
This enables the `ValidationController` to keep track of its bindings by property name, then validate bindings inspecting their rules for dependencies and if found validate those bindings too.

This also introduces `ValidationRule` and `RulesContainer` as interfaces to define abstract validation rules and an object to contain them, which instruct implementations to build their rules making sure they have a common mean to specify dependencies.

Plus, a common metadata-key to save rules on types.

(Includes https://github.com/aurelia/validation/pull/278)