### PR TITLE
feat(validation-controller): improve subproperty validation

### DIFF
--- a/dist/amd/validation-controller.js
+++ b/dist/amd/validation-controller.js
@@ -161,7 +161,13 @@ define(['exports', 'aurelia-dependency-injection', './validator', './validate-tr
       var object = _getPropertyInfo.object;
       var property = _getPropertyInfo.property;
 
-      var newErrors = this.validator.validateProperty(object, property, rules);
+      var nesting = [];
+      if (binding._observerSlots > 1) {
+        for (var x = 0; x < binding._observerSlots; x++) {
+          nesting.push(binding['_observer' + x].propertyName);
+        }
+      }
+      var newErrors = this.validator.validateProperty(object, property, rules, { bindingContext: binding.source.bindingContext, hierarchy: nesting });
       this._updateErrors(errors, newErrors, target);
       return errors;
     };

--- a/dist/aurelia-validation.js
+++ b/dist/aurelia-validation.js
@@ -238,7 +238,15 @@ export class ValidationController {
   _validateBinding(binding) {
     const { target, rules, errors } = this.bindings.get(binding);
     const { object, property } = getPropertyInfo(binding.sourceExpression, binding.source);
-    const newErrors = this.validator.validateProperty(object, property, rules);
+    const  nesting=[];
+    if (binding._observerSlots > 1)
+    {
+        for (let x=0; x<binding._observerSlots; x++)
+        {
+            nesting.push(binding['_observer'+x].propertyName);
+        }
+    }
+    const newErrors = this.validator.validateProperty(object, property, rules, {bindingContext:binding.source.bindingContext, hierarchy:nesting});
     this._updateErrors(errors, newErrors, target);
     return errors;
   }

--- a/dist/commonjs/validation-controller.js
+++ b/dist/commonjs/validation-controller.js
@@ -168,7 +168,13 @@ var ValidationController = exports.ValidationController = (_dec = (0, _aureliaDe
     var object = _getPropertyInfo.object;
     var property = _getPropertyInfo.property;
 
-    var newErrors = this.validator.validateProperty(object, property, rules);
+    var nesting = [];
+    if (binding._observerSlots > 1) {
+      for (var x = 0; x < binding._observerSlots; x++) {
+        nesting.push(binding['_observer' + x].propertyName);
+      }
+    }
+    var newErrors = this.validator.validateProperty(object, property, rules, { bindingContext: binding.source.bindingContext, hierarchy: nesting });
     this._updateErrors(errors, newErrors, target);
     return errors;
   };

--- a/dist/es2015/validation-controller.js
+++ b/dist/es2015/validation-controller.js
@@ -88,7 +88,13 @@ export let ValidationController = (_dec = inject(Validator), _dec(_class = class
   _validateBinding(binding) {
     const { target, rules, errors } = this.bindings.get(binding);
     const { object, property } = getPropertyInfo(binding.sourceExpression, binding.source);
-    const newErrors = this.validator.validateProperty(object, property, rules);
+    const nesting = [];
+    if (binding._observerSlots > 1) {
+      for (let x = 0; x < binding._observerSlots; x++) {
+        nesting.push(binding['_observer' + x].propertyName);
+      }
+    }
+    const newErrors = this.validator.validateProperty(object, property, rules, { bindingContext: binding.source.bindingContext, hierarchy: nesting });
     this._updateErrors(errors, newErrors, target);
     return errors;
   }

--- a/dist/native-modules/validation-controller.js
+++ b/dist/native-modules/validation-controller.js
@@ -158,7 +158,13 @@ export var ValidationController = (_dec = inject(Validator), _dec(_class = funct
     var object = _getPropertyInfo.object;
     var property = _getPropertyInfo.property;
 
-    var newErrors = this.validator.validateProperty(object, property, rules);
+    var nesting = [];
+    if (binding._observerSlots > 1) {
+      for (var x = 0; x < binding._observerSlots; x++) {
+        nesting.push(binding['_observer' + x].propertyName);
+      }
+    }
+    var newErrors = this.validator.validateProperty(object, property, rules, { bindingContext: binding.source.bindingContext, hierarchy: nesting });
     this._updateErrors(errors, newErrors, target);
     return errors;
   };

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -8,7 +8,7 @@ System.register(['./aurelia-validation'], function (_export, _context) {
       var _exportObj = {};
 
       for (var _key in _aureliaValidation) {
-        if (_key !== "default" && key !== "__esModule") _exportObj[_key] = _aureliaValidation[_key];
+        if (_key !== "default" && _key !== "__esModule") _exportObj[_key] = _aureliaValidation[_key];
       }
 
       _export(_exportObj);

--- a/dist/system/validation-controller.js
+++ b/dist/system/validation-controller.js
@@ -169,7 +169,13 @@ System.register(['aurelia-dependency-injection', './validator', './validate-trig
           var object = _getPropertyInfo.object;
           var property = _getPropertyInfo.property;
 
-          var newErrors = this.validator.validateProperty(object, property, rules);
+          var nesting = [];
+          if (binding._observerSlots > 1) {
+            for (var x = 0; x < binding._observerSlots; x++) {
+              nesting.push(binding['_observer' + x].propertyName);
+            }
+          }
+          var newErrors = this.validator.validateProperty(object, property, rules, { bindingContext: binding.source.bindingContext, hierarchy: nesting });
           this._updateErrors(errors, newErrors, target);
           return errors;
         };

--- a/dist/temp/aurelia-validation.js
+++ b/dist/temp/aurelia-validation.js
@@ -262,7 +262,13 @@ var ValidationController = exports.ValidationController = (_dec = (0, _aureliaDe
     var object = _getPropertyInfo.object;
     var property = _getPropertyInfo.property;
 
-    var newErrors = this.validator.validateProperty(object, property, rules);
+    var nesting = [];
+    if (binding._observerSlots > 1) {
+      for (var x = 0; x < binding._observerSlots; x++) {
+        nesting.push(binding['_observer' + x].propertyName);
+      }
+    }
+    var newErrors = this.validator.validateProperty(object, property, rules, { bindingContext: binding.source.bindingContext, hierarchy: nesting });
     this._updateErrors(errors, newErrors, target);
     return errors;
   };

--- a/src/validation-controller.js
+++ b/src/validation-controller.js
@@ -118,7 +118,15 @@ export class ValidationController {
   _validateBinding(binding) {
     const { target, rules, errors } = this.bindings.get(binding);
     const { object, property } = getPropertyInfo(binding.sourceExpression, binding.source);
-    const newErrors = this.validator.validateProperty(object, property, rules);
+    const  nesting=[];
+    if (binding._observerSlots > 1)
+    {
+        for (let x=0; x<binding._observerSlots; x++)
+        {
+            nesting.push(binding['_observer'+x].propertyName);
+        }
+    }
+    const newErrors = this.validator.validateProperty(object, property, rules, {bindingContext:binding.source.bindingContext, hierarchy:nesting});
     this._updateErrors(errors, newErrors, target);
     return errors;
   }


### PR DESCRIPTION
Pass additional information to the validator when validating a subproperty so it
will be able to correctly identify what is being validated and what rules need
to be run.

No breaking changes the additional data is passed as a 4th argument to the
validator's _validate() method.