### PR TITLE
fix(ValidationController): ensure binding.source is not null

### DIFF
--- a/src/validation-controller.ts
+++ b/src/validation-controller.ts
@@ -329,10 +329,12 @@ export class ValidationController {
   * Validates the property associated with a binding.
   */
   validateBinding(binding: Binding) {
-    const { object, propertyName } = getPropertyInfo(<Expression>binding.sourceExpression, (<any>binding).source);
-    const registeredBinding = this.bindings.get(binding);
-    const rules = registeredBinding ? registeredBinding.rules : undefined; 
-    this.validate({ object, propertyName, rules });
+    if ((<any>binding).source !== null) {
+      const { object, propertyName } = getPropertyInfo(<Expression>binding.sourceExpression, (<any>binding).source);
+      const registeredBinding = this.bindings.get(binding);
+      const rules = registeredBinding ? registeredBinding.rules : undefined; 
+      this.validate({ object, propertyName, rules });
+    }
   }
 
   /**


### PR DESCRIPTION
Handle the case when Binding Behavior event listener triggers validation before unbind, the listener is already firing during unbind (race condition).

Closes #293