### PR TITLE
IE does not support closest

### DIFF
--- a/doc/article/en-US/validation-basics.md
+++ b/doc/article/en-US/validation-basics.md
@@ -458,8 +458,12 @@ Custom renderers implement a one-method interface: `render(instruction: RenderIn
       }
 
       private add(element: Element, error: ValidationError) {
-        const formGroup = element.closest('.form-group');
-        if (!formGroup) {
+        let formGroup = element.parentElement;
+        while (formGroup.nodeName !== "BODY" && !formGroup.classList.contains('form-group')) {
+          formGroup = formGroup.parentElement;
+        }
+
+        if (formGroup.nodeName === "BODY") {
           return;
         }
         
@@ -475,8 +479,12 @@ Custom renderers implement a one-method interface: `render(instruction: RenderIn
       }
 
       private remove(element: Element, error: ValidationError) {
-        const formGroup = element.closest('.form-group');
-        if (!formGroup) {
+        let formGroup = element.parentElement;
+        while (formGroup.nodeName !== "BODY" && !formGroup.classList.contains('form-group')) {
+          formGroup = formGroup.parentElement;
+        }
+
+        if (formGroup.nodeName === "BODY") {
           return;
         }
 
@@ -496,10 +504,6 @@ Custom renderers implement a one-method interface: `render(instruction: RenderIn
 </code-listing>
 
 To use a custom renderer you'll need to instantiate it and pass it to your controller via the `addRenderer` method. Any of the controller's existing errors will be renderered immediately. You can remove a renderer using the `removeRenderer` method. Removing a renderer will unrender any errors that renderer had previously rendered.
-
-
-> Warning
-> The renderer example uses `Element.closest`. You'll need to [polyfill](https://github.com/jonathantneal/closest) this method in Internet Explorer.
 
 ## [Entity Validation](aurelia-doc://section/8/version/1.0.0)
 


### PR DESCRIPTION
I still argue for the sake of simplicity not to have the overhead and burden of using a polyfill. I also had to make change to the code to use `element` instead of `target`. I tested this change as well. The thinking is that I can either copy and paste what is given or I have to install and configure my app to use a polyfill for a method that is only used in two places. A 5 second fix or 5 minute fix. This change also follows the belief of not relying on other peoples code.