### PR TITLE
implemented validation decorators

### DIFF
--- a/src/aurelia-validation.ts
+++ b/src/aurelia-validation.ts
@@ -16,6 +16,7 @@ export * from './implementation/standard-validator';
 export * from './implementation/validation-messages';
 export * from './implementation/validation-parser';
 export * from './implementation/validation-rules';
+export * from './implementation/decorators';
 
 // Configuration
 

--- a/src/implementation/decorators.ts
+++ b/src/implementation/decorators.ts
@@ -1,0 +1,100 @@
+import { Rule, Rules, ValidationRules, FluentRuleCustomizer } from "../aurelia-validation";
+
+export type RuleCustomizer = ((c: FluentRuleCustomizer<any, any>) => FluentRuleCustomizer<any, any>) | null;
+export type SatisfiesRule = (value: any, object?: any) => boolean | Promise<boolean>;
+
+export function addRules(target: any, rules: Rule<any, any>[]) {
+    var existingRules = Rules.get(target) || [];
+    Rules.set(target, existingRules.concat(rules));
+}
+
+export function applyCustomizer(propertyRule: FluentRuleCustomizer<any, any>, customizer: RuleCustomizer = null) {
+    return typeof customizer === "function" ? customizer(propertyRule) : propertyRule;
+}
+
+export function satisfies(rule: SatisfiesRule, customizer: RuleCustomizer = null): Function {
+    return function (target: any, propertyKey: string) {
+        var isClassLevel = typeof target == 'function';
+        var inspectedObj = isClassLevel ? ValidationRules.ensureObject() : ValidationRules.ensure(propertyKey);
+        var targetRule = inspectedObj.satisfies(rule);
+        addRules(isClassLevel? target.prototype : target, applyCustomizer(targetRule, customizer).rules);
+    }
+}
+
+export function satisfiesRule(ruleName: string, customizer: RuleCustomizer = null): Function {
+    return function (target: any, propertyKey: string) {
+        var isClassLevel = typeof target == 'function';
+        var inspectedObj = isClassLevel ? ValidationRules.ensureObject() : ValidationRules.ensure<any, any>(propertyKey);
+        var targetRule = inspectedObj.satisfiesRule(ruleName);
+        addRules(isClassLevel? target.prototype : target, applyCustomizer(targetRule, customizer).rules);
+    }
+}
+
+export function required(customizer: RuleCustomizer = null): PropertyDecorator {
+    return function (target: Object, propertyKey: string) {
+        var propertyRule = ValidationRules.ensure(propertyKey).required();
+        addRules(target, applyCustomizer(propertyRule, customizer).rules);
+    };
+}
+
+export function matches(regex: RegExp, customizer: RuleCustomizer = null): PropertyDecorator {
+    return function (target: Object, propertyKey: string) {
+        var propertyRule = ValidationRules.ensure(propertyKey).matches(regex);
+        addRules(target, applyCustomizer(propertyRule, customizer).rules);
+    };
+}
+
+export function minLength(length: number, customizer: RuleCustomizer = null): PropertyDecorator {
+    return function (target: Object, propertyKey: string) {
+        var propertyRule = ValidationRules.ensure(propertyKey).minLength(length);
+        addRules(target, applyCustomizer(propertyRule, customizer).rules);
+    }
+}
+export function maxLength(length: number, customizer: RuleCustomizer = null): PropertyDecorator {
+    return function (target: Object, propertyKey: string) {
+        var propertyRule = ValidationRules.ensure(propertyKey).maxLength(length);
+        addRules(target, applyCustomizer(propertyRule, customizer).rules);
+    }
+}
+
+export function minItems(count: number, customizer: RuleCustomizer = null): PropertyDecorator {
+    return function (target: Object, propertyKey: string) {
+        var propertyRule = ValidationRules.ensure(propertyKey).minItems(count);
+        addRules(target, applyCustomizer(propertyRule, customizer).rules);
+    }
+}
+
+export function maxItems(count: number, customizer: RuleCustomizer = null): PropertyDecorator {
+    return function (target: Object, propertyKey: string) {
+        var propertyRule = ValidationRules.ensure(propertyKey).maxItems(count);
+        addRules(target, applyCustomizer(propertyRule, customizer).rules);
+    }
+}
+
+export function numeric(customizer: RuleCustomizer = null): PropertyDecorator {
+    return function (target: Object, propertyKey: string) {
+        var propertyRule = ValidationRules.ensure(propertyKey).satisfies((value: any) => !isNaN(parseFloat(value)) && isFinite(value));
+        addRules(target, applyCustomizer(propertyRule, customizer).rules);
+    }
+}
+
+export function email(customizer: RuleCustomizer = null): PropertyDecorator {
+    return function (target: Object, propertyKey: string) {
+        var propertyRule = ValidationRules.ensure(propertyKey).email();
+        addRules(target, applyCustomizer(propertyRule, customizer).rules);
+    }
+}
+
+export function equals(value: any, customizer: RuleCustomizer = null): PropertyDecorator {
+    return function (target: Object, propertyKey: string) {
+        var propertyRule = ValidationRules.ensure(propertyKey).equals(value);
+        addRules(target, applyCustomizer(propertyRule, customizer).rules);
+    }
+}
+
+export function url(customizer: RuleCustomizer = null): PropertyDecorator {
+    return function (target: any, propertyKey: string) {
+        var propertyRule = ValidationRules.ensure(propertyKey).matches(/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/);
+        addRules(target, applyCustomizer(propertyRule, customizer).rules);
+    }
+}

--- a/test/decorators.ts
+++ b/test/decorators.ts
@@ -1,0 +1,60 @@
+import {StageComponent, ComponentTester} from 'aurelia-testing';
+import {Aurelia} from 'aurelia-framework';
+import {bootstrap} from 'aurelia-bootstrapper';
+import {Rules, email, minLength, equals, satisfies} from '../src/aurelia-validation';
+
+function configure(aurelia: Aurelia) {
+  aurelia.use
+    .standardConfiguration()
+    .plugin('dist/test/src/aurelia-validation')
+    .feature('./dist/test/test/resources');
+}
+
+describe('end to end', () => {
+  it('decorators', (done: () => void) => {
+    const component: ComponentTester = StageComponent
+      .withResources()
+      .boundTo({});
+    component.bootstrap(configure);
+    
+    (<Promise<any>>component.create(<any>bootstrap))
+      .then(() => {
+        @satisfies((o:TestClass)=>o.property4=="_value_")
+        class TestClass
+        {
+            @email(c=>c.withMessageKey('_email'))
+            property1: string;
+            @minLength(6, c=>c.withMessage("Must be min 6 symbols"))
+            property2: string;
+            @equals('password', c=>c.when((o:TestClass)=>o.property1 == "pro@kr.nt"))
+            @satisfies(()=>true)
+            property3: boolean;
+
+            @equals("_value_")
+            get property4()
+            {
+              return "_value_";
+            }
+        }
+
+        var obj = new TestClass();
+        var rules = Rules.get(obj);
+        
+        expect(rules.length).toEqual(6);
+        expect(rules[0].property.name).toEqual('property1');
+        expect(rules[0].messageKey).toEqual('_email');
+        expect(rules[1].message.value).toEqual("Must be min 6 symbols");
+        expect(rules[3].when).not.toBeNull();
+        expect(rules[3].messageKey).toEqual("equals");
+        expect(rules[4].messageKey).toEqual("equals");
+        
+        rules.forEach((element, index) => {
+          console.log(index);
+          console.log(JSON.stringify(element));
+        });
+
+      })
+      .then(() => component.dispose())
+      .then(done);
+  });
+});


### PR DESCRIPTION
Implemented https://github.com/aurelia/validation/issues/287
Sample:

```typescript
@satisfiesRule("rule")
@satisfies((o:Model)=><rule>)
class Model {
    @required
    firstName: string;

    @required(customizer => customizer.withMessageKey('myMessage'))
    lastName: string;

    @email
    @required(customizer => customizer
        .when((model: Model) => model.sendEmail)
        .withMessage('Email is required when shipment notifications have been requested.')
    )
    email: string;

    sendEmail: boolean;

    @satisfiesRule("address")
    @satisfies((o:Model)=> <rule>)
    physicalAddress: Address;
}
```