### PR TITLE
feat(ValidationControllerFactory): add Validator parameter to createForCurrentScope

### DIFF
--- a/src/validation-controller-factory.ts
+++ b/src/validation-controller-factory.ts
@@ -1,5 +1,6 @@
 import {Container} from 'aurelia-dependency-injection';
 import {ValidationController} from './validation-controller';
+import {Validator} from './validator';
 
 /**
  * Creates ValidationController instances.
@@ -15,16 +16,16 @@ export class ValidationControllerFactory {
    * Creates a new controller and registers it in the current element's container so that it's 
    * available to the validate binding behavior and renderers.
    */
-  create() {
-    return this.container.invoke(ValidationController);
+  create(validator?: Validator) {
+    return this.container.invoke(ValidationController, [validator]);
   }
 
   /**
    * Creates a new controller and registers it in the current element's container so that it's 
    * available to the validate binding behavior and renderers.
    */
-  createForCurrentScope() {
-    const controller = this.create();
+  createForCurrentScope(validator?: Validator) {
+    const controller = this.create(validator);
     this.container.registerInstance(ValidationController, controller);
     return controller;
   }

--- a/src/validation-controller.ts
+++ b/src/validation-controller.ts
@@ -1,3 +1,4 @@
+import {Container} from 'aurelia-dependency-injection';
 import {Binding, Expression} from 'aurelia-binding';
 import {Validator} from './validator';
 import {validateTrigger} from './validate-trigger';
@@ -43,7 +44,6 @@ export interface ValidateInstruction {
  * Exposes the current list of validation errors for binding purposes.
  */
 export class ValidationController {
-  static inject = [Validator];
 
   // Registered bindings (via the validate binding behavior)
   private bindings = new Map<Binding, BindingInfo>();
@@ -75,7 +75,11 @@ export class ValidationController {
   // Promise that resolves when validation has completed.
   private finishValidating = Promise.resolve();
 
-  constructor(private validator: Validator) {}
+  constructor(private validator: Validator) {
+    if (!validator) {
+          this.validator = Container.instance.get(Validator);
+    }
+  }
 
   /**
    * Adds an object to the set of objects that should be validated when validate is called.

--- a/test/validation-controller-factory.ts
+++ b/test/validation-controller-factory.ts
@@ -1,7 +1,8 @@
 import {Container, Optional} from 'aurelia-dependency-injection';
 import {
   ValidationControllerFactory,
-  ValidationController
+  ValidationController,
+  Validator
 } from '../src/aurelia-validation';
 
 describe('ValidationControllerFactory', () => {
@@ -12,5 +13,17 @@ describe('ValidationControllerFactory', () => {
     const controller = factory.createForCurrentScope();
     expect(container.get(Optional.of(ValidationController))).toBe(null);
     expect(childContainer.get(Optional.of(ValidationController))).toBe(controller);
+  });
+
+  it('createForCurrentScopeWithValidator', () => {
+    const container = new Container();
+    const childContainer = container.createChild();
+
+    const factory = childContainer.get(ValidationControllerFactory);
+    const validator = childContainer.get(Validator);
+
+    const controller = factory.createForCurrentScope(validator);
+
+    expect(controller.validator).toBe(validator);
   });
 });

--- a/test/validation-controller-factory.ts
+++ b/test/validation-controller-factory.ts
@@ -1,8 +1,7 @@
 import {Container, Optional} from 'aurelia-dependency-injection';
 import {
   ValidationControllerFactory,
-  ValidationController,
-  Validator
+  ValidationController
 } from '../src/aurelia-validation';
 
 describe('ValidationControllerFactory', () => {
@@ -18,12 +17,11 @@ describe('ValidationControllerFactory', () => {
   it('createForCurrentScopeWithValidator', () => {
     const container = new Container();
     const childContainer = container.createChild();
-
     const factory = childContainer.get(ValidationControllerFactory);
-    const validator = childContainer.get(Validator);
+    const validator = {};
 
     const controller = factory.createForCurrentScope(validator);
-
+   
     expect(controller.validator).toBe(validator);
   });
 });


### PR DESCRIPTION
feat(ValidationControllerFactory): add Validator parameter to createForCurrentScope

It is not currently possible to provide a Validater to a specific
instance of ValidationController, at least, not without using injection.

ValidationControllerFactory.createForCurrentScope has been provided to enable
us to instantiate ValidationController without the use of injection, but
provides no means of supplying a Validator for the controller instance.

I have a use case where the ValidationController needs to be
instantiated without the use of injection because the code is in a base
class where, due to javascript/typescript limitations, injection cannot
be used.

Note: I'm not altering the documentation because it ties into:

1) documentation about configuring the plugin, which I believe is
missing altogether
2) other means of assigning a Validator to a controller (through
injection) that I understand are being added but may yet have been
documented.

Thus I think someone with more broad knowledge of all of this should
undertake the task of documenting the whole thing together.