### PR TITLE
feat(scripts): use cross-env and rifraf for cross environment scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,15 +20,15 @@
     "url": "https://github.com/aurelia/validation"
   },
   "scripts": {
-    "test": "./node_modules/.bin/tsc && ./node_modules/karma/bin/karma start --single-run",
+    "test": "cross-env ./node_modules/.bin/tsc && cross-env ./node_modules/karma/bin/karma start --single-run",
     "test-watch": "concurrently \"./node_modules/.bin/tsc --watch\" \"./node_modules/karma/bin/karma start\"",
-    "prebuild:compile": "del 'dist/**'",
-    "build:compile": "concurrently \"node_modules/.bin/tsc --project tsconfig.build.json --outDir dist/amd\" \"node_modules/.bin/tsc --project tsconfig.build.json --outDir dist/commonjs --module commonjs\" \"node_modules/.bin/tsc --project tsconfig.build.json --outDir dist/native-modules --module es2015\" \"node_modules/.bin/tsc --project tsconfig.build.json --outDir dist/system --module system\" \"node_modules/.bin/tsc --project tsconfig.build.json --outDir dist/es2015 --target es2015 --module es2015\" || true",
+    "prebuild:compile": "rimraf 'dist/**'",
+    "build:compile": "concurrently \"node_modules/.bin/tsc --project tsconfig.build.json --outDir dist/amd\" \"./node_modules/.bin/tsc --project tsconfig.build.json --outDir dist/commonjs --module commonjs\" \"./node_modules/.bin/tsc --project tsconfig.build.json --outDir dist/native-modules --module es2015\" \"./node_modules/.bin/tsc --project tsconfig.build.json --outDir dist/system --module system\" \"./node_modules/.bin/tsc --project tsconfig.build.json --outDir dist/es2015 --target es2015 --module es2015\" || true",
     "build": "npm run build:compile",
     "postbuild": "npm run build:doc",
-    "prebuild:doc": "del 'doc/api.json' && del 'dist/doc-temp/**' && node_modules/.bin/tsc --project tsconfig.build.json --outFile dist/doc-temp/aurelia-validation.js && node doc/shape-defs",
-    "build:doc": "./node_modules/.bin/typedoc --json doc/api.json --excludeExternals --includeDeclarations --mode modules --target ES6 --name aurelia-validation-docs --ignoreCompilerErrors --tsconfig doc/tsconfig.json dist/doc-temp/",
-    "postbuild:doc": "concurrently \"node doc/shape-doc\" \"del 'dist/doc-temp/**'\""
+    "prebuild:doc": "rimraf 'doc/api.json' && rimraf 'dist/doc-temp/**' && cross-env ./node_modules/.bin/tsc --project tsconfig.build.json --outFile dist/doc-temp/aurelia-validation.js && node doc/shape-defs",
+    "build:doc": "cross-env ./node_modules/.bin/typedoc --json doc/api.json --excludeExternals --includeDeclarations --mode modules --target ES6 --name aurelia-validation-docs --ignoreCompilerErrors --tsconfig doc/tsconfig.json dist/doc-temp/",
+    "postbuild:doc": "concurrently \"node doc/shape-doc\" \"rimraf 'dist/doc-temp/**'\""
   },
   "jspm": {
     "registry": "npm",
@@ -70,7 +70,7 @@
     "aurelia-polyfills": "^1.1.0",
     "aurelia-testing": "^1.0.0-beta.2.0.0",
     "concurrently": "^2.2.0",
-    "del-cli": "^0.2.0",
+    "cross-env": "^2.0.1",
     "jasmine-core": "^2.4.1",
     "karma": "^1.2.0",
     "karma-chrome-launcher": "^2.0.0",
@@ -79,6 +79,7 @@
     "karma-requirejs": "^1.0.0",
     "requirejs": "^2.2.0",
     "requirejs-text": "^2.0.12",
+    "rimraf": "^2.5.4",
     "typedoc": "^0.4.5",
     "typescript": "^2.0.0"
   },


### PR DESCRIPTION
test and build works
*unrelated': build:doc fails with `TypeError: Cannot read property 'flags' of undefined`. maybe someone else can chip in

closes https://github.com/aurelia/validation/issues/337