### PR TITLE
doc(basic): add missing then()

### DIFF
--- a/doc/article/en-US/validation-basics.md
+++ b/doc/article/en-US/validation-basics.md
@@ -157,7 +157,8 @@ Rules are evaluated in parallel. Use the `.then()` method to postpone evaluation
         .required()
         .minLength(3)
         .maxLength(50)
-        .satisfiesRule('usernameNotInUse')
+        .then()
+        .satisfiesRule('usernameNotInUse');
   </source-code>
 </code-listing>
 


### PR DESCRIPTION
I believe `.then()` is missing in the second sequencing example in order to make `usernameNotInUse` be evaluated after the first 3 pass.

Also adds a missing semicolon.