### PR TITLE
Fix incorrect @inject sample

### DIFF
--- a/doc/article/en-US/validation-basics.md
+++ b/doc/article/en-US/validation-basics.md
@@ -321,7 +321,7 @@ Use the `manual` trigger to indicate the controller should not automatically val
   <source-code lang="ES 2015">
     import {ValidationControllerFactory, validateTrigger} from 'aurelia-validation';
 
-    @inject(ValidationControllerFactory))
+    @inject(ValidationControllerFactory)
     export class RegistrationForm {
       controller = null;
 


### PR DESCRIPTION
The "Setting the validate trigger" example used an incorrect `inject` attribute (one closing parenthesis too many).