### PR TITLE
fix: fixed the issue when getting the container from the controller for aurelia custom element

### DIFF
--- a/src/validate-binding-behavior-base.ts
+++ b/src/validate-binding-behavior-base.ts
@@ -28,7 +28,8 @@ export abstract class ValidateBindingBehaviorBase {
     for (let i = 0, ii = view.controllers.length; i < ii; i++) {
       let controller: any = view.controllers[i];
       if (controller.viewModel === target) {
-        const element = controller.container.get(DOM.Element);
+        let container = controller.container || controller.view.container || controller.viewModel.container;
+        const element = container.get(DOM.Element);
         if (element) {
           return element;
         }


### PR DESCRIPTION
When valid on a custom element, the validator throws an error, because it can not get the correct container:

``
vendor-bundle.js:23500 ERROR [app-router] TypeError: Cannot read property 'get' of undefined
    at ValidateBindingBehaviorBase.getTarget (http://localhost:9000/scripts/vendor-bundle.js:35538:55)
    at ValidateBindingBehaviorBase.bind (http://localhost:9000/scripts/vendor-bundle.js:35550:31)
    at BindingBehavior.bind (http://localhost:9000/scripts/vendor-bundle.js:15247:21)
    at Binding.bind (http://localhost:9000/scripts/vendor-bundle.js:18757:31)
    at Controller.bind (http://localhost:9000/scripts/vendor-bundle.js:31238:19)
    at View.bind (http://localhost:9000/scripts/vendor-bundle.js:29299:24)
    at Controller.bind (http://localhost:9000/scripts/vendor-bundle.js:31260:19)
    at Controller.automate (http://localhost:9000/scripts/vendor-bundle.js:31205:12)
    at RouterView.swap (http://localhost:9000/scripts/vendor-bundle.js:33655:38)
    at http://localhost:9000/scripts/vendor-bundle.js:33615:15
    at tryCatcher (http://localhost:9000/scripts/vendor-bundle.js:3297:23)
    at Promise._settlePromiseFromHandler (http://localhost:9000/scripts/vendor-bundle.js:2505:31)
    at Promise._settlePromise (http://localhost:9000/scripts/vendor-bundle.js:2562:18)
    at Promise._settlePromise0 (http://localhost:9000/scripts/vendor-bundle.js:2607:10)
    at Promise._settlePromises (http://localhost:9000/scripts/vendor-bundle.js:2686:18)
    at Promise._fulfill (http://localhost:9000/scripts/vendor-bundle.js:2631:18)
``

