### PR TITLE
Small typo in i18n ValidationMessageProvider usage example

### DIFF
--- a/doc/article/en-US/validation-basics.md
+++ b/doc/article/en-US/validation-basics.md
@@ -780,7 +780,7 @@ Here's how to override the methods, in your main.js, during application startup:
       ...
       ...
 
-      const i18n = aurelia.container.get(i18n);
+      const i18n = aurelia.container.get(I18N);
       ValidationMessageProvider.prototype.getMessage = function(key) {
         const translation = i18n.tr(`errorMessages.${key}`);
         return this.parser.parseMessage(translation);


### PR DESCRIPTION
Casing was off and example did not work as-is.