### PR TITLE
Regex pattern does not match generated validation functions

### DIFF
--- a/src/implementation/validation-parser.ts
+++ b/src/implementation/validation-parser.ts
@@ -86,7 +86,9 @@ export class ValidationParser {
   }
 
   private getAccessorExpression(fn: string): Expression {
-    const classic = /^function\s*\([$_\w\d]+\)\s*\{\s*(?:"use strict";)?\s*return\s+[$_\w\d]+\.([$_\w\d]+)\s*;?\s*\}$/;
+    /* tslint:disable:max-line-length */
+    const classic = /^function\s*\([$_\w\d]+\)\s*\{(?:\s*"use strict";)?\s*(?:[$_\w\d.['"\]+;]+)?\s*return\s+[$_\w\d]+\.([$_\w\d]+)\s*;?\s*\}$/;
+    /* tslint:enable:max-line-length */
     const arrow = /^\(?[$_\w\d]+\)?\s*=>\s*[$_\w\d]+\.([$_\w\d]+)$/;
     const match = classic.exec(fn) || arrow.exec(fn);
     if (match === null) {

--- a/test/validation-parser.ts
+++ b/test/validation-parser.ts
@@ -35,6 +35,14 @@ describe('Validator', () => {
     expect(parse('(x) => x.name')).toEqual(new AccessScope('name', 0));
   });
 
+  it('parses generated function bodies', () => {
+    const parse: (fn: string) => Expression = (parser as any).getAccessorExpression.bind(parser);
+    expect(parse('function(a){__gen$field.f[\'10\']++;__aGen$field.g[\'10\']++;return a.b;}'))
+      .toEqual(new AccessScope('b', 0));
+    expect(parse('function(a){"use strict";_gen$field.f[\'10\']++;_aGen$field.g[\'10\']++;return a.b;}'))
+      .toEqual(new AccessScope('b', 0));
+  });
+
   it('parses properties', () => {
     expect(parser.parseProperty('firstName')).toEqual({ name: 'firstName', displayName: null });
     expect(parser.parseProperty('3_letter_id')).toEqual({ name: '3_letter_id', displayName: null });


### PR DESCRIPTION
This enables the code to parse the function below.
'  ------------------------------------------------
Inner Error:
Message: Unable to parse accessor function:
function (field){__cov_Y78wk1Q$EdTFqyA$ttpw0g.f['7']++;__cov_Y78wk1Q$EdTFqyA$ttpw0g.s['17']++;return field.number;}
Inner Error Stack:
Error: Unable to parse accessor function:
function (field){__cov_Y78wk1Q$EdTFqyA$ttpw0g.f['7']++;__cov_Y78wk1Q$EdTFqyA$ttpw0g.s['17']++;return field.number;}
    at ValidationParser.getAccessorExpression (http://localhost:9876/base/jspm_packages/npm/aurelia-validation@1.0.0-beta.1.0.1/implementation/validation-parser.js:57:23)
    at ValidationParser.parseProperty (http://localhost:9876/base/jspm_packages/npm/aurelia-validation@1.0.0-beta.1.0.1/implementation/validation-parser.js:38:33)
    at FluentEnsure.ensure (http://localhost:9876/base/jspm_packages/npm/aurelia-validation@1.0.0-beta.1.0.1/implementation/validation-rules.js:330:67)
    at Function.ValidationRules.ensure (http://localhost:9876/base/jspm_packages/npm/aurelia-validation@1.0.0-beta.1.0.1/implementation/validation-rules.js:379:61)
    at PhoneNumberValidator.createRuleFor (http://localhost:9876/base/src/validators/phone-number/index.js:9:1710)
    at PhoneNumberValidator.getTelephoneValidationRulesFor (http://localhost:9876/base/src/validators/phone-number/index.js:9:1108)
    at ContactNumbers.setupValidation (http://localhost:9876/base/src/components/contact-numbers/index.js:9:6362)
    at new ContactNumbers (http://localhost:9876/base/src/components/contact-numbers/index.js:9:6013)
    at Object.invoke (http://localhost:9876/base/jspm_packages/npm/aurelia-dependency-injection@1.2.1/aurelia-dependency-injection.js:445:14)
    at InvocationHandler.invoke (http://localhost:9876/base/jspm_packages/npm/aurelia-dependency-injection@1.2.1/aurelia-dependency-injection.js:410:168)
End Inner Error Stack
'  ------------------------------------------------