### PR TITLE
PR: add alternative to fluent rule api that enables creating rules from data - 363

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log*
 .test
 dist/doc-temp
 dist/test
+*.bak

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "cross-env tslint --project tsconfig.json",
     "pretest": "cross-env npm run lint",
     "test": "cross-env rimraf dist && tsc && karma start --single-run",
-    "develop": "concurrently \"./node_modules/.bin/tsc --watch\" \"./node_modules/.bin/karma start\"",
+    "develop": "concurrently \"tsc --watch\" \"karma start\"",
     "prebuild:amd": "cross-env rimraf dist/amd",
     "build:amd": "cross-env tsc --project tsconfig.build.json --outDir dist/amd --module amd",
     "postbuild:amd": "cross-env copyfiles --up 1 src/**/*.html src/**/*.css dist/amd",

--- a/src/implementation/standard-validator.ts
+++ b/src/implementation/standard-validator.ts
@@ -146,7 +146,7 @@ export class StandardValidator extends Validator {
     }
 
     // any rules?
-    if (!rules) {
+    if (!rules || (rules.length === 0)) {
       return Promise.resolve([]);
     }
 

--- a/src/implementation/validation-messages.ts
+++ b/src/implementation/validation-messages.ts
@@ -37,11 +37,7 @@ export class ValidationMessageProvider {
    */
   public getMessage(key: string): Expression {
     let message: string;
-    if (key in validationMessages) {
-      message = validationMessages[key];
-    } else {
-      message = validationMessages['default'];
-    }
+    message = (key in validationMessages) ? validationMessages[key] : validationMessages['default'];
     return this.parser.parse(message);
   }
 

--- a/src/implementation/validation-rules.ts
+++ b/src/implementation/validation-rules.ts
@@ -676,45 +676,34 @@ export class ValidationRules {
   }
 
   // tslint:disable:max-line-length
-
-  // /**
-  //  * Target a property with validation rules.
-  //  * @param property The property to target. Can be the property name or a property accessor function.
-  //  */
-  // // tslint:disable-next-line:max-line-length
-  // public static ensure<TObject, TValue>(property: string | PropertyAccessor<TObject, TValue>): FluentRules<TObject, TValue> {
-  //   // this works just as well:
-  //   // return new FluentRulesGenerator<TObject>(new FluentEnsure<TObject>(ValidationRules.parsers)).ensure(property);
-  //   return new FluentEnsure<TObject>(ValidationRules.parsers).ensure(property);
-  // }
-
-  // /**
-  //  * Targets an object with validation rules.
-  //  */
-  // public static ensureObject<TObject>(): FluentRules<TObject, any> {
-  //   // this works just as well:
-  //   // return new FluentRulesGenerator<TObject>(new FluentEnsure<TObject>(ValidationRules.parsers)).ensureObject();
-  //   return new FluentEnsure<TObject>(ValidationRules.parsers).ensureObject();
-  // }
-
-  // tslint:enable:max-line-length
-
   /**
    * Target a property with validation rules.
    * @param property The property to target. Can be the property name or a property accessor function.
    */
-  // tslint:disable-next-line:max-line-length
   public static ensure<TObject, TValue>(property: string | PropertyAccessor<TObject, TValue>): FluentRulesGenerator<TObject> {
     return new FluentRulesGenerator<TObject>(new FluentEnsure<TObject>(ValidationRules.parsers)).ensure(property);
   }
-
   /**
    * Targets an object with validation rules.
    */
   public static ensureObject<TObject>(): FluentRulesGenerator<TObject> {
     return new FluentRulesGenerator<TObject>(new FluentEnsure<TObject>(ValidationRules.parsers)).ensureObject();
   }
+  // tslint:enable:max-line-length
+  // /**
+  //  * Target a property with validation rules.
+  //  * @param property The property to target. Can be the property name or a property accessor function.
+  //  */
+  // public static ensure<TObject, TValue>(property: string | PropertyAccessor<TObject, TValue>) {
+  //   return new FluentEnsure<TObject>(ValidationRules.parsers).ensure(property);
+  // }
 
+  // /**
+  //  * Targets an object with validation rules.
+  //  */
+  // public static ensureObject<TObject>() {
+  //   return new FluentEnsure<TObject>(ValidationRules.parsers).ensureObject();
+  // }
   /**
    * Defines a custom rule.
    * @param name The name of the custom rule. Also serves as the message key.

--- a/src/implementation/validation-rules.ts
+++ b/src/implementation/validation-rules.ts
@@ -680,30 +680,23 @@ export class ValidationRules {
    * Target a property with validation rules.
    * @param property The property to target. Can be the property name or a property accessor function.
    */
+  // public static ensure<TObject, TValue>(property: string | PropertyAccessor<TObject, TValue>) {
+  //   return new FluentEnsure<TObject>(ValidationRules.parsers).ensure(property);
+  // }
   public static ensure<TObject, TValue>(property: string | PropertyAccessor<TObject, TValue>): FluentRulesGenerator<TObject> {
     return new FluentRulesGenerator<TObject>(new FluentEnsure<TObject>(ValidationRules.parsers)).ensure(property);
   }
+
   /**
    * Targets an object with validation rules.
    */
+  // public static ensureObject<TObject>() {
+  //   return new FluentEnsure<TObject>(ValidationRules.parsers).ensureObject();
+  // }
   public static ensureObject<TObject>(): FluentRulesGenerator<TObject> {
     return new FluentRulesGenerator<TObject>(new FluentEnsure<TObject>(ValidationRules.parsers)).ensureObject();
   }
   // tslint:enable:max-line-length
-  // /**
-  //  * Target a property with validation rules.
-  //  * @param property The property to target. Can be the property name or a property accessor function.
-  //  */
-  // public static ensure<TObject, TValue>(property: string | PropertyAccessor<TObject, TValue>) {
-  //   return new FluentEnsure<TObject>(ValidationRules.parsers).ensure(property);
-  // }
-
-  // /**
-  //  * Targets an object with validation rules.
-  //  */
-  // public static ensureObject<TObject>() {
-  //   return new FluentEnsure<TObject>(ValidationRules.parsers).ensureObject();
-  // }
   /**
    * Defines a custom rule.
    * @param name The name of the custom rule. Also serves as the message key.

--- a/src/validation-controller.ts
+++ b/src/validation-controller.ts
@@ -104,11 +104,7 @@ export class ValidationController {
     propertyName: string | PropertyAccessor<TObject, string> | null = null
   ): ValidateResult {
     let resolvedPropertyName: string | null;
-    if (propertyName === null) {
-      resolvedPropertyName = propertyName;
-    } else {
-      resolvedPropertyName = this.propertyParser.parse(propertyName);
-    }
+    resolvedPropertyName = (propertyName === null) ? propertyName : this.propertyParser.parse(propertyName);
     const result = new ValidateResult({ __manuallyAdded__: true }, object, resolvedPropertyName, false, message);
     this.processResultDelta('validate', [], [result]);
     return result;
@@ -176,11 +172,8 @@ export class ValidationController {
     if (instruction) {
       const { object, propertyName, rules } = instruction;
       let predicate: (result: ValidateResult) => boolean;
-      if (instruction.propertyName) {
-        predicate = x => x.object === object && x.propertyName === propertyName;
-      } else {
-        predicate = x => x.object === object;
-      }
+      predicate = (instruction.propertyName) ? x => x.object === object && x.propertyName === propertyName :
+        x => x.object === object;
       if (rules) {
         return x => predicate(x) && this.validator.ruleExists(rules, x.rule);
       }
@@ -204,13 +197,11 @@ export class ValidationController {
       // if rules were not specified, check the object map.
       rules = rules || this.objects.get(object);
       // property specified?
-      if (instruction.propertyName === undefined) {
-        // validate the specified object.
-        execute = () => this.validator.validateObject(object, rules);
-      } else {
-        // validate the specified property.
-        execute = () => this.validator.validateProperty(object, propertyName, rules);
-      }
+      execute = (instruction.propertyName === undefined) ?
+        // validate the specified object
+        () => this.validator.validateObject(object, rules) :
+        // validate the specified property
+        () => this.validator.validateProperty(object, propertyName, rules);
     } else {
       // validate all objects and bindings.
       execute = () => {

--- a/test/resources/registration-form.ts
+++ b/test/resources/registration-form.ts
@@ -45,6 +45,7 @@ ValidationRules.customRule(
     || obj[otherPropertyName] === undefined
     || obj[otherPropertyName] === ''
     || value === obj[otherPropertyName],
+  // tslint:disable-next-line:no-invalid-template-strings
   '${$displayName} must match ${$getDisplayName($config.otherPropertyName)}',
   otherPropertyName => ({ otherPropertyName })
 );
@@ -54,7 +55,9 @@ ValidationRules
   .ensure(f => f.lastName).required()
   .ensure('email').required().email()
   .ensure(f => f.number1).satisfies(value => value > 0)
-  .ensure(f => f.number2).satisfies(value => value > 0).withMessage('${displayName} gots to be greater than zero.')
+  .ensure(f => f.number2).satisfies(value => value > 0)
+  // tslint:disable-next-line:no-invalid-template-strings
+  .withMessage('${displayName} gots to be greater than zero.')
   .ensure(f => f.password).required()
   .ensure(f => f.confirmPassword).required().satisfiesRule('matchesProperty', 'password')
   .on(RegistrationForm);

--- a/test/validation-message-parser.ts
+++ b/test/validation-message-parser.ts
@@ -15,8 +15,10 @@ describe('ValidationMessageParser', () => {
 
   it('parses', () => {
     expect(parser.parse('test') instanceof LiteralString).toBe(true);
+    // tslint:disable-next-line:no-invalid-template-strings
     expect(parser.parse('${$value} is invalid') instanceof Binary).toBe(true);
     // tslint:disable-next-line:max-line-length
+    // tslint:disable-next-line:no-invalid-template-strings
     expect(parser.parse('${$value} should equal ${$object.foo.bar().baz ? object.something[0] : \'test\'}') instanceof Binary).toBe(true);
   });
 });

--- a/test/validator.ts
+++ b/test/validator.ts
@@ -233,6 +233,7 @@ describe('Validator', () => {
       })
       .then((results: Array<ValidateResult>) => {
         expect(results.length).toEqual(2);
+        expect(results[0].valid).toEqual(false);
         expect(results[0].message).toEqual(messageRequiredConfirm);
         // a little weird since it actually isn't valid, it just hasn't been tested
         expect(results[1].valid).toEqual(true);
@@ -255,6 +256,28 @@ describe('Validator', () => {
         expect(results.length).toEqual(2);
         expect(results[0].valid).toEqual(true);
         expect(results[1].message).toEqual(messageMinLengthConfirm);
+        rules = ValidationRules
+          .ensure(propertyName)
+          .required()
+          .displayName(displayName)
+          .withMessage(messageRequired)
+          .then()
+          .ensure(propertyName) // <= challenge is putting another ensure after a then
+          .maxLength(5)
+          .withMessage(messageMinLength)
+          .on(obj)
+          .rules;
+
+        delete obj.name;
+        return validator.validateObject(obj, rules);
+      })
+      .then((results: Array<ValidateResult>) => {
+        // make sure 'then' is working
+        expect(results.length).toEqual(2);
+        expect(results[0].valid).toEqual(false);
+        expect(results[0].message).toEqual(messageRequiredConfirm);
+        // a little weird since it actually isn't valid, it just hasn't been tested
+        expect(results[1].valid).toEqual(true);
 
         rules = ValidationRules
           .ensure(propertyName)
@@ -272,6 +295,7 @@ describe('Validator', () => {
         obj.name = 'abc';
         return validator.validateObject(obj, rules);
       })
+
       .then((results: Array<ValidateResult>) => {
         expect(results.length).toEqual(2);
         expect(results[0].valid).toEqual(true);


### PR DESCRIPTION
This PR proposes a way to answer #363.  

This is the second PR I've done on this.  The first is [here](https://github.com/aurelia/validation/pull/432). 

This PR is the same as the previous one, except that the conflicts with the master branch are resolved.  (I am creating the new PR because (sheepishly) I deleted the repository on which the first PR was based.

Please refer to the [first PR](https://github.com/aurelia/validation/pull/432) to see the original descriptions and discussion.

In response to @jdanyow's concern about changing the API, the only non-additive changes that I am aware of are that `ValidationRules.ensure` and `ValidationRules.ensureObject` are now each returning `FluentRulesGenerator<TObject>` instead of `FluentEnsure<TObject>`.   

This should only affect someone who is compiling TypeScript and who explicitly expects `FluentEnsure<TObject>`.  But I expect that the people most likely to be in that situation are the people mostly likely to welcome this code change, because it will simplify their code, likely absolving them of the need to care what types those two methods are returning (see the code example in the original PR).

Beyond that, the API is unchanged and works as before, only with more flexibility and fewer moving parts.

There is a small loss of contextual intellisense, but because the API is more flexible with this change, the intellisense is not so useful.  There remain only four methods that must be called in a particular sequence:

* `withMessageKey(key: string)`
*  `withMessage(message: string)`
*  `when(condition: (object: TObject) => boolean)`
*  `tag(tag: string)`

These four have to be called after at least one rule has been defined. This makes intuitive sense because they all act to modify a rule. I am throwing an exception if they are called too soon.