### PR TITLE
fix(ValidationMessageProvider): increase visibility of parser field

### DIFF
--- a/src/implementation/validation-messages.ts
+++ b/src/implementation/validation-messages.ts
@@ -29,7 +29,7 @@ export const validationMessages: ValidationMessages = {
 export class ValidationMessageProvider {
   public static inject = [ValidationMessageParser];
 
-  constructor(private parser: ValidationMessageParser) { }
+  constructor(parser: ValidationMessageParser) { }
 
   /**
    * Returns a message binding expression that corresponds to the key.


### PR DESCRIPTION
This change increases the visibility of the parser field inside `ValidationMessageProvider` from `private` to `public`.

The validation documentation shows overriding `ValidationMessageProvider.getMessage`. However, as parser is `private`, the overriden method cannot call `this.parser`.

This change fixes https://github.com/aurelia/validation/issues/464