### PR TITLE
fix(StandardValidator): change to handle empty rule sets

### DIFF
--- a/dist/amd/implementation/standard-validator.js
+++ b/dist/amd/implementation/standard-validator.js
@@ -126,7 +126,7 @@ define(["require", "exports", "aurelia-templating", "../validator", "../validate
                 rules = rules_1.Rules.get(object);
             }
             // any rules?
-            if (!rules) {
+            if (!rules || rules.length === 0) {
                 return Promise.resolve([]);
             }
             return this.validateRuleSequence(object, propertyName, rules, 0, []);

--- a/dist/commonjs/implementation/standard-validator.js
+++ b/dist/commonjs/implementation/standard-validator.js
@@ -130,7 +130,7 @@ var StandardValidator = /** @class */ (function (_super) {
             rules = rules_1.Rules.get(object);
         }
         // any rules?
-        if (!rules) {
+        if (!rules || rules.length === 0) {
             return Promise.resolve([]);
         }
         return this.validateRuleSequence(object, propertyName, rules, 0, []);

--- a/dist/es2015/implementation/standard-validator.js
+++ b/dist/es2015/implementation/standard-validator.js
@@ -112,7 +112,7 @@ export class StandardValidator extends Validator {
             rules = Rules.get(object);
         }
         // any rules?
-        if (!rules) {
+        if (!rules || rules.length === 0) {
             return Promise.resolve([]);
         }
         return this.validateRuleSequence(object, propertyName, rules, 0, []);

--- a/dist/es2017/implementation/standard-validator.js
+++ b/dist/es2017/implementation/standard-validator.js
@@ -112,7 +112,7 @@ export class StandardValidator extends Validator {
             rules = Rules.get(object);
         }
         // any rules?
-        if (!rules) {
+        if (!rules || rules.length === 0) {
             return Promise.resolve([]);
         }
         return this.validateRuleSequence(object, propertyName, rules, 0, []);

--- a/dist/native-modules/implementation/standard-validator.js
+++ b/dist/native-modules/implementation/standard-validator.js
@@ -128,7 +128,7 @@ var StandardValidator = /** @class */ (function (_super) {
             rules = Rules.get(object);
         }
         // any rules?
-        if (!rules) {
+        if (!rules || rules.length === 0) {
             return Promise.resolve([]);
         }
         return this.validateRuleSequence(object, propertyName, rules, 0, []);

--- a/dist/system/implementation/standard-validator.js
+++ b/dist/system/implementation/standard-validator.js
@@ -142,7 +142,7 @@ System.register(["aurelia-templating", "../validator", "../validate-result", "./
                         rules = rules_1.Rules.get(object);
                     }
                     // any rules?
-                    if (!rules) {
+                    if (!rules || rules.length === 0) {
                         return Promise.resolve([]);
                     }
                     return this.validateRuleSequence(object, propertyName, rules, 0, []);

--- a/src/implementation/standard-validator.ts
+++ b/src/implementation/standard-validator.ts
@@ -146,7 +146,7 @@ export class StandardValidator extends Validator {
     }
 
     // any rules?
-    if (!rules) {
+    if (!rules || rules.length === 0) {
       return Promise.resolve([]);
     }
 

--- a/test/validator.ts
+++ b/test/validator.ts
@@ -127,4 +127,11 @@ describe('Validator', () => {
       })
       .then(done);
   });
+
+  it('handles empty rulesets', (done: () => void) => {
+    const obj = { prop: 'test', __rules__: [] };
+
+    validator.validateProperty(obj, 'test', null)
+      .then(done);
+  });
 });


### PR DESCRIPTION
fix(StandardValidator): change to handle empty rule sets
Validation Controller fails on empty rules array
#483