### PR TITLE
Fix number property accessors, small tslint fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "editor.formatOnSave": true,
+  "tslint.nodePath": "./node_modules/tslint/bin/tslint",
+  "editor.formatOnSave": false,
   "json.format.enable": false,
   "typescript.format.enable": true
 }

--- a/src/implementation/rule.ts
+++ b/src/implementation/rule.ts
@@ -9,7 +9,7 @@ export interface RuleProperty {
   /**
    * The property name. null indicates the rule targets the object itself.
    */
-  name: string | null;
+  name: string | number | null;
 
   /**
    * The displayName of the property (or object).

--- a/src/implementation/standard-validator.ts
+++ b/src/implementation/standard-validator.ts
@@ -31,7 +31,7 @@ export class StandardValidator extends Validator {
    * @param rules Optional. If unspecified, the rules will be looked up using the metadata
    * for the object created by ValidationRules....on(class/object)
    */
-  public validateProperty(object: any, propertyName: string, rules?: any): Promise<ValidateResult[]> {
+  public validateProperty(object: any, propertyName: string | number, rules?: any): Promise<ValidateResult[]> {
     return this.validate(object, propertyName, rules || null);
   }
 
@@ -84,7 +84,7 @@ export class StandardValidator extends Validator {
 
   private validateRuleSequence(
     object: any,
-    propertyName: string | null,
+    propertyName: string | number | null,
     ruleSequence: Rule<any, any>[][],
     sequence: number,
     results: ValidateResult[]
@@ -137,7 +137,7 @@ export class StandardValidator extends Validator {
 
   private validate(
     object: any,
-    propertyName: string | null,
+    propertyName: string | number | null,
     rules: Rule<any, any>[][] | null
   ): Promise<ValidateResult[]> {
     // rules specified?

--- a/src/implementation/standard-validator.ts
+++ b/src/implementation/standard-validator.ts
@@ -101,7 +101,8 @@ export class StandardValidator extends Validator {
       const rule = rules[i];
 
       // is the rule related to the property we're validating.
-      if (!validateAllProperties && rule.property.name !== propertyName) {
+      // tslint:disable-next-line:triple-equals | Use loose equality for property keys
+      if (!validateAllProperties && rule.property.name != propertyName) {
         continue;
       }
 
@@ -117,21 +118,21 @@ export class StandardValidator extends Validator {
         promiseOrBoolean = Promise.resolve(promiseOrBoolean);
       }
       promises.push(promiseOrBoolean.then(valid => {
-        const message = valid ? null : this.getMessage(rule, object, value);
-        results.push(new ValidateResult(rule, object, rule.property.name, valid, message));
-        allValid = allValid && valid;
-        return valid;
-      }));
+          const message = valid ? null : this.getMessage(rule, object, value);
+          results.push(new ValidateResult(rule, object, rule.property.name, valid, message));
+          allValid = allValid && valid;
+          return valid;
+        }));
     }
 
     return Promise.all(promises)
       .then(() => {
-        sequence++;
-        if (allValid && sequence < ruleSequence.length) {
-          return this.validateRuleSequence(object, propertyName, ruleSequence, sequence, results);
-        }
-        return results;
-      });
+      sequence++;
+      if (allValid && sequence < ruleSequence.length) {
+        return this.validateRuleSequence(object, propertyName, ruleSequence, sequence, results);
+      }
+      return results;
+    });
   }
 
   private validate(

--- a/src/implementation/validation-messages.ts
+++ b/src/implementation/validation-messages.ts
@@ -51,13 +51,13 @@ export class ValidationMessageProvider {
    * Override this with your own custom logic.
    * @param propertyName The property name.
    */
-  public getDisplayName(propertyName: string, displayName?: string | null | (() => string)): string {
+  public getDisplayName(propertyName: string | number, displayName?: string | null | (() => string)): string {
     if (displayName !== null && displayName !== undefined) {
       return (displayName instanceof Function) ? displayName() : displayName as string;
     }
 
     // split on upper-case letters.
-    const words = propertyName.split(/(?=[A-Z])/).join(' ');
+    const words = propertyName.toString().split(/(?=[A-Z])/).join(' ');
     // capitalize first letter.
     return words.charAt(0).toUpperCase() + words.slice(1);
   }

--- a/src/implementation/validation-messages.ts
+++ b/src/implementation/validation-messages.ts
@@ -29,7 +29,7 @@ export const validationMessages: ValidationMessages = {
 export class ValidationMessageProvider {
   public static inject = [ValidationMessageParser];
 
-  constructor(parser: ValidationMessageParser) { }
+  constructor(public parser: ValidationMessageParser) { }
 
   /**
    * Returns a message binding expression that corresponds to the key.

--- a/src/implementation/validation-rules.ts
+++ b/src/implementation/validation-rules.ts
@@ -411,8 +411,9 @@ export class FluentEnsure<TObject> {
     throw new Error(`Did you forget to add ".plugin('aurelia-validation')" to your main.js?`);
   }
 
-  private mergeRules(fluentRules: FluentRules<TObject, any>, propertyName: string | null) {
-    const existingRules = this.rules.find(r => r.length > 0 && r[0].property.name === propertyName);
+  private mergeRules(fluentRules: FluentRules<TObject, any>, propertyName: string | number | null) {
+    // tslint:disable-next-line:triple-equals | Use loose equality for property keys
+    const existingRules = this.rules.find(r => r.length > 0 && r[0].property.name == propertyName);
     if (existingRules) {
       const rule = existingRules[existingRules.length - 1];
       fluentRules.sequence = rule.sequence;

--- a/src/implementation/validation-rules.ts
+++ b/src/implementation/validation-rules.ts
@@ -364,7 +364,7 @@ export class FluentEnsure<TObject> {
    * @param property The property to target. Can be the property name or a property accessor
    * function.
    */
-  public ensure<TValue>(property: string | PropertyAccessor<TObject, TValue>) {
+  public ensure<TValue>(property: string | number | PropertyAccessor<TObject, TValue>) {
     this.assertInitialized();
     const name = this.parsers.property.parse(property);
     const fluentRules = new FluentRules<TObject, TValue>(
@@ -442,7 +442,7 @@ export class ValidationRules {
    * Target a property with validation rules.
    * @param property The property to target. Can be the property name or a property accessor function.
    */
-  public static ensure<TObject, TValue>(property: string | PropertyAccessor<TObject, TValue>) {
+  public static ensure<TObject, TValue>(property: string | number | PropertyAccessor<TObject, TValue>) {
     return new FluentEnsure<TObject>(ValidationRules.parsers).ensure(property);
   }
 

--- a/src/property-accessor-parser.ts
+++ b/src/property-accessor-parser.ts
@@ -3,7 +3,7 @@ import {
   AccessMember,
   AccessScope
 } from 'aurelia-binding';
-import { isString } from './util';
+import { isString, isNumber } from './util';
 
 export type PropertyAccessor<TObject, TValue> = (object: TObject) => TValue;
 
@@ -12,9 +12,9 @@ export class PropertyAccessorParser {
 
   constructor(private parser: Parser) { }
 
-  public parse<TObject, TValue>(property: string | number | PropertyAccessor<TObject, TValue>): string {
-    if (isString(property)) {
-      return property as string;
+  public parse<TObject, TValue>(property: string | number | PropertyAccessor<TObject, TValue>): string | number {
+    if (isString(property) || isNumber(property)) {
+      return property as string | number;
     }
     const accessorText = getAccessorExpression(property.toString());
     const accessor = this.parser.parse(accessorText);

--- a/src/property-accessor-parser.ts
+++ b/src/property-accessor-parser.ts
@@ -12,7 +12,7 @@ export class PropertyAccessorParser {
 
   constructor(private parser: Parser) { }
 
-  public parse<TObject, TValue>(property: string | PropertyAccessor<TObject, TValue>): string {
+  public parse<TObject, TValue>(property: string | number | PropertyAccessor<TObject, TValue>): string {
     if (isString(property)) {
       return property as string;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,7 @@
 export function isString(value: any): boolean {
   return Object.prototype.toString.call(value) === '[object String]';
 }
+
+export function isNumber(value: any): boolean {
+  return Object.prototype.toString.call(value) === '[object Number]';
+}

--- a/src/validate-result.ts
+++ b/src/validate-result.ts
@@ -18,7 +18,7 @@ export class ValidateResult {
   constructor(
     public rule: any,
     public object: any,
-    public propertyName: string | null,
+    public propertyName: string | number | null,
     public valid: boolean,
     public message: string | null = null
   ) {

--- a/src/validation-controller.ts
+++ b/src/validation-controller.ts
@@ -103,7 +103,7 @@ export class ValidationController {
     object: TObject,
     propertyName: string | PropertyAccessor<TObject, string> | null = null
   ): ValidateResult {
-    let resolvedPropertyName: string | null;
+    let resolvedPropertyName: string | number | null;
     if (propertyName === null) {
       resolvedPropertyName = propertyName;
     } else {

--- a/test/property-accessor-parser.ts
+++ b/test/property-accessor-parser.ts
@@ -19,6 +19,7 @@ describe('PropertyAccessorParser', () => {
     expect(parser.parse('firstName')).toEqual('firstName');
     expect(parser.parse('3_letter_id')).toEqual('3_letter_id');
     expect(parser.parse('. @$# ???')).toEqual('. @$# ???');
+    expect(parser.parse(42)).toEqual(42);
     expect(parser.parse((x: any) => x.firstName)).toEqual('firstName');
   });
 

--- a/test/validator.ts
+++ b/test/validator.ts
@@ -85,6 +85,68 @@ describe('Validator', () => {
       .then(done);
   });
 
+  it('handles numeric properties', (done: () => void) => {
+    const objStr = {} as any;
+    objStr['2'] = 'test';
+    const objNum = {} as any;
+    objNum[2] = 'test';
+
+    const rulesStr = ValidationRules.ensure('2').equals('test').rules;
+    const rulesNum = ValidationRules.ensure(2).equals('test').rules;
+    Promise.resolve()
+      .then(() => {
+        return validator.validateProperty(objStr, 2, rulesStr);
+      })
+      .then(results => {
+        const expected = [new ValidateResult(rulesStr[0][0], objStr, '2', true, null)];
+        expected[0].id = results[0].id;
+        expect(results).toEqual(expected);
+        return validator.validateProperty(objNum, 2, rulesStr);
+      })
+      .then(results => {
+        const expected = [new ValidateResult(rulesStr[0][0], objNum, '2', true, null)];
+        expected[0].id = results[0].id;
+        expect(results).toEqual(expected);
+        return validator.validateProperty(objStr, '2', rulesStr);
+      })
+      .then(results => {
+        const expected = [new ValidateResult(rulesStr[0][0], objStr, '2', true, null)];
+        expected[0].id = results[0].id;
+        expect(results).toEqual(expected);
+        return validator.validateProperty(objNum, '2', rulesStr);
+      })
+      .then(results => {
+        const expected = [new ValidateResult(rulesStr[0][0], objNum, '2', true, null)];
+        expected[0].id = results[0].id;
+        expect(results).toEqual(expected);
+        return validator.validateProperty(objStr, 2, rulesNum);
+      })
+      .then(results => {
+        const expected = [new ValidateResult(rulesNum[0][0], objStr, 2, true, null)];
+        expected[0].id = results[0].id;
+        expect(results).toEqual(expected);
+        return validator.validateProperty(objNum, 2, rulesNum);
+      })
+      .then(results => {
+        const expected = [new ValidateResult(rulesNum[0][0], objNum, 2, true, null)];
+        expected[0].id = results[0].id;
+        expect(results).toEqual(expected);
+        return validator.validateProperty(objStr, '2', rulesNum);
+      })
+      .then(results => {
+        const expected = [new ValidateResult(rulesNum[0][0], objStr, 2, true, null)];
+        expected[0].id = results[0].id;
+        expect(results).toEqual(expected);
+        return validator.validateProperty(objNum, '2', rulesNum);
+      })
+      .then(results => {
+        const expected = [new ValidateResult(rulesNum[0][0], objNum, 2, true, null)];
+        expected[0].id = results[0].id;
+        expect(results).toEqual(expected);
+      })
+      .then(done);
+  });
+
   it('bails', (done: () => void) => {
     let obj = { prop: 'invalid email', prop2: '' };
     const spy1 = jasmine.createSpy().and.returnValue(true);


### PR DESCRIPTION
Property keys are currently compared using strict equality. This should be loose equality since that's how they work natively too.

Example:

```
const obj1 = { 2: 'text' };
const obj2 = { '2': 'text' };
obj1[2] === obj1['2'] // true
obj2[2] === obj2['2'] // true
obj1[2] === obj2[2] // true
obj1['2'] === obj2['2'] // true
```

This PR fixes that. Closes #474

Also disabled `formatOnSave` and set the `tslint` sdk path in `.vscode/settings.json` because otherwise any contributer with other global settings will have to manually change this in the settings.json (or it's impossible to save any file with the correct formatting). And fixed a small linting error.