### PR TITLE
fix(BindingBehaviors): add explicit name

### DIFF
--- a/src/aurelia-validation.ts
+++ b/src/aurelia-validation.ts
@@ -68,7 +68,7 @@ export class AureliaValidationConfiguration {
  */
 export function configure(
   // tslint:disable-next-line:ban-types
-  frameworkConfig: { container: Container, globalResources?: (...resources: Function[]) => any },
+  frameworkConfig: { container: Container, globalResources?: (...resources: any[]) => any },
   callback?: (config: AureliaValidationConfiguration) => void
 ) {
   // the fluent rule definition API needs the parser to translate messages

--- a/src/validate-binding-behavior.ts
+++ b/src/validate-binding-behavior.ts
@@ -2,12 +2,14 @@ import { TaskQueue } from 'aurelia-task-queue';
 import { ValidationController } from './validation-controller';
 import { validateTrigger } from './validate-trigger';
 import { ValidateBindingBehaviorBase } from './validate-binding-behavior-base';
+import { bindingBehavior } from 'aurelia-binding';
 
 /**
  * Binding behavior. Indicates the bound property should be validated
  * when the validate trigger specified by the associated controller's
  * validateTrigger property occurs.
  */
+@bindingBehavior('validate')
 export class ValidateBindingBehavior extends ValidateBindingBehaviorBase {
   public static inject = [TaskQueue];
 
@@ -21,6 +23,7 @@ export class ValidateBindingBehavior extends ValidateBindingBehaviorBase {
  * manually, by calling controller.validate(). No automatic validation
  * triggered by data-entry or blur will occur.
  */
+@bindingBehavior('validateManually')
 export class ValidateManuallyBindingBehavior extends ValidateBindingBehaviorBase {
   public static inject = [TaskQueue];
 
@@ -33,6 +36,7 @@ export class ValidateManuallyBindingBehavior extends ValidateBindingBehaviorBase
  * Binding behavior. Indicates the bound property should be validated
  * when the associated element blurs.
  */
+@bindingBehavior('validateOnBlur')
 export class ValidateOnBlurBindingBehavior extends ValidateBindingBehaviorBase {
   public static inject = [TaskQueue];
 
@@ -46,6 +50,7 @@ export class ValidateOnBlurBindingBehavior extends ValidateBindingBehaviorBase {
  * when the associated element is changed by the user, causing a change
  * to the model.
  */
+@bindingBehavior('validateOnChange')
 export class ValidateOnChangeBindingBehavior extends ValidateBindingBehaviorBase {
   public static inject = [TaskQueue];
 
@@ -59,6 +64,7 @@ export class ValidateOnChangeBindingBehavior extends ValidateBindingBehaviorBase
  * when the associated element blurs or is changed by the user, causing
  * a change to the model.
  */
+@bindingBehavior('validateOnChangeOrBlur')
 export class ValidateOnChangeOrBlurBindingBehavior extends ValidateBindingBehaviorBase {
   public static inject = [TaskQueue];
 


### PR DESCRIPTION
@jdanyow Sorry I checked again and realized I forgot to name the binding behavior explicitly, it will break in production without it, because all class names will be mangled. There is a minor change in entry to ensure type definition works fine with static registration:
```js
import { configure as validationPlugin } from 'aurelia-validation'

export function configure(aurelia) {
  aurelia.use.plugin(validationPlugin)
}
```