### PR TITLE
Update typings.json

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -1,4 +1,4 @@
 {
   "name": "aurelia-validation",
-  "main": "dist/amd/aurelia-validation.d.ts"
+  "main": "dist/types/aurelia-validation.d.ts"
 }


### PR DESCRIPTION
Fix issue where typings.json was pointing to wrong location.

```
> typings install github:aurelia/validation                                                                                                                                
typings WARN badlocation "github:aurelia/validation" is mutable and may change, consider specifying a commit hash                                                          
typings ERR! message Unable to read typings for "aurelia-validation". You should check the entry paths in "typings.json" are up to date                                    
typings ERR! caused by https://raw.githubusercontent.com/aurelia/validation/master/dist/amd/aurelia-validation.d.ts/index.d.ts responded with 404, expected it to equal 200
```