### PR TITLE
refactor(build): add umd build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "license": "MIT",
   "author": "Jeremy Danyow <jdanyow@gmail.com> (https:/danyow.net/)",
   "main": "dist/commonjs/aurelia-validation.js",
+  "module": "dist/es2015/aurelia-validation.js",
+  "browser": "dist/umd/aurelia-validation.js",
+  "unpkg": "dist/umd/aurelia-validation.js",
   "types": "dist/aurelia-validation.d.ts",
   "typings": "dist/aurelia-validation.d.ts",
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,10 +11,25 @@ const entryName = 'aurelia-validation';
 
 export default [{
   input: `src/${entryName}.ts`,
-  output: {
-    file: `dist/es2015/${entryName}.js`,
-    format: 'es'
-  },
+  output: [
+    {
+      file: `dist/es2015/${entryName}.js`,
+      format: 'es'
+    },
+    {
+      file: `dist/umd/${entryName}.js`,
+      format: 'umd',
+      name: 'au.validation',
+      globals: {
+        'aurelia-binding': 'au',
+        'aurelia-templating': 'au',
+        'aurelia-dependency-injection': "au",
+        "aurelia-logging": "au.LogManager",
+        "aurelia-pal": "au",
+        "aurelia-task-queue": "au",
+      }
+    }
+  ],
   plugins: [
     typescript({
       useTsconfigDeclarationDir: true,


### PR DESCRIPTION
Add umd build to enable usage with aurelia-script in umd format:

```js
aurelia.use.plugin(au.validation.configure)
```

@jdanyow @EisenbergEffect 