### PR TITLE
feat(config): support global config option for default validation trigger

### DIFF
--- a/src/aurelia-validation.ts
+++ b/src/aurelia-validation.ts
@@ -1,5 +1,6 @@
 // Exports
 
+export * from './config';
 export * from './controller-validate-result';
 export * from './get-target-dom-element';
 export * from './property-info';
@@ -26,8 +27,7 @@ export * from './implementation/validation-rules';
 // Configuration
 
 import { Container } from 'aurelia-dependency-injection';
-import { Validator } from './validator';
-import { StandardValidator } from './implementation/standard-validator';
+import { AureliaValidationConfiguration } from './config';
 import { ValidationMessageParser } from './implementation/validation-message-parser';
 import { PropertyAccessorParser } from './property-accessor-parser';
 import { ValidationRules } from './implementation/validation-rules';
@@ -40,28 +40,6 @@ import {
 } from './validate-binding-behavior';
 import { ValidationErrorsCustomAttribute } from './validation-errors-custom-attribute';
 import { ValidationRendererCustomAttribute } from './validation-renderer-custom-attribute';
-
-/**
- * Aurelia Validation Configuration API
- */
-export class AureliaValidationConfiguration {
-  private validatorType: { new (...args: any[]): Validator } = StandardValidator;
-
-  /**
-   * Use a custom Validator implementation.
-   */
-  public customValidator(type: { new (...args: any[]): Validator }) {
-    this.validatorType = type;
-  }
-
-  /**
-   * Applies the configuration.
-   */
-  public apply(container: Container) {
-    const validator = container.get(this.validatorType);
-    container.registerInstance(Validator, validator);
-  }
-}
 
 /**
  * Configures the plugin.

--- a/src/aurelia-validation.ts
+++ b/src/aurelia-validation.ts
@@ -27,7 +27,7 @@ export * from './implementation/validation-rules';
 // Configuration
 
 import { Container } from 'aurelia-dependency-injection';
-import { AureliaValidationConfiguration } from './config';
+import { GlobalValidationConfiguration } from './config';
 import { ValidationMessageParser } from './implementation/validation-message-parser';
 import { PropertyAccessorParser } from './property-accessor-parser';
 import { ValidationRules } from './implementation/validation-rules';
@@ -47,7 +47,7 @@ import { ValidationRendererCustomAttribute } from './validation-renderer-custom-
 export function configure(
   // tslint:disable-next-line:ban-types
   frameworkConfig: { container: Container, globalResources?: (...resources: any[]) => any },
-  callback?: (config: AureliaValidationConfiguration) => void
+  callback?: (config: GlobalValidationConfiguration) => void
 ) {
   // the fluent rule definition API needs the parser to translate messages
   // to interpolation expressions.
@@ -56,7 +56,7 @@ export function configure(
   ValidationRules.initialize(messageParser, propertyParser);
 
   // configure...
-  const config = new AureliaValidationConfiguration();
+  const config = new GlobalValidationConfiguration();
   if (callback instanceof Function) {
     callback(config);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,36 @@
+import { Container } from 'aurelia-dependency-injection';
+import { Validator } from './validator';
+import { StandardValidator } from './implementation/standard-validator';
+import { validateTrigger } from './validate-trigger';
+
+/**
+ * Aurelia Validation Configuration API
+ */
+export class AureliaValidationConfiguration {
+  private validatorType: { new (...args: any[]): Validator } = StandardValidator;
+  private validationTrigger = validateTrigger.blur;
+
+  /**
+   * Use a custom Validator implementation.
+   */
+  public customValidator(type: { new (...args: any[]): Validator }) {
+    this.validatorType = type;
+  }
+
+  public defaultValidationTrigger(trigger: validateTrigger) {
+    this.validationTrigger = trigger;
+  }
+
+  public getDefaultValidationTrigger() {
+    return this.validationTrigger;
+  }
+
+  /**
+   * Applies the configuration.
+   */
+  public apply(container: Container) {
+    const validator = container.get(this.validatorType);
+    container.registerInstance(Validator, validator);
+    container.registerInstance(AureliaValidationConfiguration, this);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,11 +6,11 @@ import { validateTrigger } from './validate-trigger';
 /**
  * Aurelia Validation Configuration API
  */
-export class AureliaValidationConfiguration {
+export class GlobalValidationConfiguration {
   public static DEFAULT_VALIDATION_TRIGGER = validateTrigger.blur;
 
   private validatorType: { new (...args: any[]): Validator } = StandardValidator;
-  private validationTrigger = AureliaValidationConfiguration.DEFAULT_VALIDATION_TRIGGER;
+  private validationTrigger = GlobalValidationConfiguration.DEFAULT_VALIDATION_TRIGGER;
 
   /**
    * Use a custom Validator implementation.
@@ -33,6 +33,6 @@ export class AureliaValidationConfiguration {
   public apply(container: Container) {
     const validator = container.get(this.validatorType);
     container.registerInstance(Validator, validator);
-    container.registerInstance(AureliaValidationConfiguration, this);
+    container.registerInstance(GlobalValidationConfiguration, this);
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,8 +7,10 @@ import { validateTrigger } from './validate-trigger';
  * Aurelia Validation Configuration API
  */
 export class AureliaValidationConfiguration {
+  public static DEFAULT_VALIDATION_TRIGGER = validateTrigger.blur;
+
   private validatorType: { new (...args: any[]): Validator } = StandardValidator;
-  private validationTrigger = validateTrigger.blur;
+  private validationTrigger = AureliaValidationConfiguration.DEFAULT_VALIDATION_TRIGGER;
 
   /**
    * Use a custom Validator implementation.

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,10 +17,12 @@ export class GlobalValidationConfiguration {
    */
   public customValidator(type: { new (...args: any[]): Validator }) {
     this.validatorType = type;
+    return this;
   }
 
   public defaultValidationTrigger(trigger: validateTrigger) {
     this.validationTrigger = trigger;
+    return this;
   }
 
   public getDefaultValidationTrigger() {

--- a/src/validation-controller-factory.ts
+++ b/src/validation-controller-factory.ts
@@ -1,5 +1,5 @@
 import { Container } from 'aurelia-dependency-injection';
-import { AureliaValidationConfiguration } from './config';
+import { GlobalValidationConfiguration } from './config';
 import { ValidationController } from './validation-controller';
 import { Validator } from './validator';
 import { PropertyAccessorParser } from './property-accessor-parser';
@@ -22,7 +22,7 @@ export class ValidationControllerFactory {
       validator = this.container.get(Validator) as Validator;
     }
     const propertyParser = this.container.get(PropertyAccessorParser) as PropertyAccessorParser;
-    const config = this.container.get(AureliaValidationConfiguration) as AureliaValidationConfiguration;
+    const config = this.container.get(GlobalValidationConfiguration) as GlobalValidationConfiguration;
     return new ValidationController(validator, propertyParser, config);
   }
 

--- a/src/validation-controller-factory.ts
+++ b/src/validation-controller-factory.ts
@@ -1,4 +1,5 @@
 import { Container } from 'aurelia-dependency-injection';
+import { AureliaValidationConfiguration } from './config';
 import { ValidationController } from './validation-controller';
 import { Validator } from './validator';
 import { PropertyAccessorParser } from './property-accessor-parser';
@@ -21,7 +22,8 @@ export class ValidationControllerFactory {
       validator = this.container.get(Validator) as Validator;
     }
     const propertyParser = this.container.get(PropertyAccessorParser) as PropertyAccessorParser;
-    return new ValidationController(validator, propertyParser);
+    const config = this.container.get(AureliaValidationConfiguration) as AureliaValidationConfiguration;
+    return new ValidationController(validator, propertyParser, config);
   }
 
   /**

--- a/src/validation-controller.ts
+++ b/src/validation-controller.ts
@@ -1,4 +1,5 @@
 import { Binding, Expression } from 'aurelia-binding';
+import { AureliaValidationConfiguration } from './config';
 import { Validator } from './validator';
 import { validateTrigger } from './validate-trigger';
 import { getPropertyInfo } from './property-info';
@@ -15,7 +16,7 @@ import { ValidateEvent } from './validate-event';
  * Exposes the current list of validation results for binding purposes.
  */
 export class ValidationController {
-  public static inject = [Validator, PropertyAccessorParser];
+  public static inject = [Validator, PropertyAccessorParser, AureliaValidationConfiguration];
 
   // Registered bindings (via the validate binding behavior)
   private bindings = new Map<Binding, BindingInfo>();
@@ -47,14 +48,20 @@ export class ValidationController {
   /**
    * The trigger that will invoke automatic validation of a property used in a binding.
    */
-  public validateTrigger = validateTrigger.blur;
+  public validateTrigger: validateTrigger;
 
   // Promise that resolves when validation has completed.
   private finishValidating: Promise<any> = Promise.resolve();
 
   private eventCallbacks: ((event: ValidateEvent) => void)[] = [];
 
-  constructor(private validator: Validator, private propertyParser: PropertyAccessorParser) { }
+  constructor(
+    private validator: Validator,
+    private propertyParser: PropertyAccessorParser,
+    config: AureliaValidationConfiguration,
+  ) {
+    this.validateTrigger = config.getDefaultValidationTrigger();
+  }
 
   /**
    * Subscribe to controller validate and reset events. These events occur when the

--- a/src/validation-controller.ts
+++ b/src/validation-controller.ts
@@ -58,9 +58,11 @@ export class ValidationController {
   constructor(
     private validator: Validator,
     private propertyParser: PropertyAccessorParser,
-    config: AureliaValidationConfiguration,
+    config?: AureliaValidationConfiguration,
   ) {
-    this.validateTrigger = config.getDefaultValidationTrigger();
+    this.validateTrigger = config instanceof AureliaValidationConfiguration
+        ? config.getDefaultValidationTrigger()
+        : AureliaValidationConfiguration.DEFAULT_VALIDATION_TRIGGER;
   }
 
   /**

--- a/src/validation-controller.ts
+++ b/src/validation-controller.ts
@@ -1,5 +1,5 @@
 import { Binding, Expression } from 'aurelia-binding';
-import { AureliaValidationConfiguration } from './config';
+import { GlobalValidationConfiguration } from './config';
 import { Validator } from './validator';
 import { validateTrigger } from './validate-trigger';
 import { getPropertyInfo } from './property-info';
@@ -16,7 +16,7 @@ import { ValidateEvent } from './validate-event';
  * Exposes the current list of validation results for binding purposes.
  */
 export class ValidationController {
-  public static inject = [Validator, PropertyAccessorParser, AureliaValidationConfiguration];
+  public static inject = [Validator, PropertyAccessorParser, GlobalValidationConfiguration];
 
   // Registered bindings (via the validate binding behavior)
   private bindings = new Map<Binding, BindingInfo>();
@@ -58,11 +58,11 @@ export class ValidationController {
   constructor(
     private validator: Validator,
     private propertyParser: PropertyAccessorParser,
-    config?: AureliaValidationConfiguration,
+    config?: GlobalValidationConfiguration,
   ) {
-    this.validateTrigger = config instanceof AureliaValidationConfiguration
+    this.validateTrigger = config instanceof GlobalValidationConfiguration
         ? config.getDefaultValidationTrigger()
-        : AureliaValidationConfiguration.DEFAULT_VALIDATION_TRIGGER;
+        : GlobalValidationConfiguration.DEFAULT_VALIDATION_TRIGGER;
   }
 
   /**

--- a/test/validation-controller-factory.ts
+++ b/test/validation-controller-factory.ts
@@ -1,8 +1,10 @@
 import { Container, Optional } from 'aurelia-dependency-injection';
 import {
+  AureliaValidationConfiguration,
   ValidationControllerFactory,
   ValidationController,
-  Validator
+  Validator,
+  validateTrigger
 } from '../src/aurelia-validation';
 
 describe('ValidationControllerFactory', () => {
@@ -10,10 +12,14 @@ describe('ValidationControllerFactory', () => {
     const container = new Container();
     const standardValidator = {};
     container.registerInstance(Validator, standardValidator);
+    const config = new AureliaValidationConfiguration();
+    config.defaultValidationTrigger(validateTrigger.manual);
+    container.registerInstance(AureliaValidationConfiguration, config);
     const childContainer = container.createChild();
     const factory = childContainer.get(ValidationControllerFactory);
     const controller = factory.createForCurrentScope();
     expect(controller.validator).toBe(standardValidator);
+    expect(controller.validateTrigger).toBe(validateTrigger.manual);
     expect(container.get(Optional.of(ValidationController))).toBe(null);
     expect(childContainer.get(Optional.of(ValidationController))).toBe(controller);
     const customValidator = {};

--- a/test/validation-controller-factory.ts
+++ b/test/validation-controller-factory.ts
@@ -1,6 +1,6 @@
 import { Container, Optional } from 'aurelia-dependency-injection';
 import {
-  AureliaValidationConfiguration,
+  GlobalValidationConfiguration,
   ValidationControllerFactory,
   ValidationController,
   Validator,
@@ -12,9 +12,9 @@ describe('ValidationControllerFactory', () => {
     const container = new Container();
     const standardValidator = {};
     container.registerInstance(Validator, standardValidator);
-    const config = new AureliaValidationConfiguration();
+    const config = new GlobalValidationConfiguration();
     config.defaultValidationTrigger(validateTrigger.manual);
-    container.registerInstance(AureliaValidationConfiguration, config);
+    container.registerInstance(GlobalValidationConfiguration, config);
     const childContainer = container.createChild();
     const factory = childContainer.get(ValidationControllerFactory);
     const controller = factory.createForCurrentScope();

--- a/test/validation-controller.ts
+++ b/test/validation-controller.ts
@@ -1,5 +1,5 @@
 import {
-  AureliaValidationConfiguration,
+  GlobalValidationConfiguration,
   PropertyAccessorParser,
   ValidationController,
   Validator,
@@ -11,10 +11,10 @@ describe('ValidationController', () => {
     const validator = {} as any as Validator;
     const parser = {} as any as PropertyAccessorParser;
     const controller = new ValidationController(validator, parser);
-    expect(controller.validateTrigger).toBe(AureliaValidationConfiguration.DEFAULT_VALIDATION_TRIGGER);
+    expect(controller.validateTrigger).toBe(GlobalValidationConfiguration.DEFAULT_VALIDATION_TRIGGER);
 
     const trigger = validateTrigger.changeOrBlur;
-    const config = new AureliaValidationConfiguration();
+    const config = new GlobalValidationConfiguration();
     config.defaultValidationTrigger(trigger);
     const controllerWithConfig = new ValidationController(validator, parser, config);
     expect(controllerWithConfig.validateTrigger).toBe(trigger);

--- a/test/validation-controller.ts
+++ b/test/validation-controller.ts
@@ -1,0 +1,22 @@
+import {
+  AureliaValidationConfiguration,
+  PropertyAccessorParser,
+  ValidationController,
+  Validator,
+  validateTrigger,
+} from '../src/aurelia-validation';
+
+describe('ValidationController', () => {
+  it('takes a validator, a PropertyAccessorParser, and optional config', () => {
+    const validator = {} as any as Validator;
+    const parser = {} as any as PropertyAccessorParser;
+    const controller = new ValidationController(validator, parser);
+    expect(controller.validateTrigger).toBe(AureliaValidationConfiguration.DEFAULT_VALIDATION_TRIGGER);
+
+    const trigger = validateTrigger.changeOrBlur;
+    const config = new AureliaValidationConfiguration();
+    config.defaultValidationTrigger(trigger);
+    const controllerWithConfig = new ValidationController(validator, parser, config);
+    expect(controllerWithConfig.validateTrigger).toBe(trigger);
+  });
+});


### PR DESCRIPTION
Fixes #535.

I moved `AureliaValidationConfiguration` to a separate file and added a method `defaultValidationTrigger` that users can call to globally configure the default validation trigger like so:

```ts
aurelia.use
  .plugin("aurelia-validation", (config: AureliaValidationConfiguration) => {
    config.defaultValidationTrigger(validateTrigger.manual);
  });
```

I wasn't sure how to get the configured trigger into the `ValidationController` so I simply opted to register the config instance and inject it.

I considered making `AureliaValidationConfiguration.getDefaultValidationTrigger()` private to present a cleaner interface to users, but decided against it since this way the call in the `ValidationController` constructor can be type-checked.